### PR TITLE
refactor(installer): optimize anonymous instance management and reset state

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ActionHandler.kt
@@ -67,14 +67,18 @@ class ActionHandler(scope: CoroutineScope, installer: InstallerRepo) :
     }
 
     private suspend fun resolve(activity: Activity) {
-        Timber.d("[id=${installer.id}] resolve: Starting.")
-        if (installer.data.isNotEmpty()) {
-            Timber.w("[id=${installer.id}] resolve: installer.data is not empty. Skipping redundant resolve.")
-            return
-        }
+        Timber.d("[id=${installer.id}] resolve: Starting new task.")
 
-        Timber.d("[id=${installer.id}] resolve: Emitting ProgressEntity.Resolving")
+        // --- Reset all state fields here at the beginning ---
+        installer.error = Throwable()
+        installer.config = ConfigEntity.default
+        installer.data = emptyList()
+        installer.entities = emptyList()
+        installer.progress.emit(ProgressEntity.Ready) // Also reset progress
+
+        Timber.d("[id=${installer.id}] resolve: State has been reset. Emitting ProgressEntity.Resolving.")
         installer.progress.emit(ProgressEntity.Resolving)
+
 
         installer.config = try {
             resolveConfig(activity)


### PR DESCRIPTION
This commit refactors the management of anonymous `InstallerRepoImpl` instances to use a direct singleton field (`anonymousInstance`) instead of tracking by ID (`anonymousInstanceId`). This simplifies the logic and aligns with typical singleton patterns.

Additionally, the `resolve` function in `ActionHandler` now resets all relevant state fields (error, config, data, entities, progress) at the beginning of its execution. This ensures a clean state for each new resolve operation, preventing potential issues from stale data.

fix #102 