### PR TITLE
feat(installer): support installing from apk remote http/https url

### DIFF
--- a/.github/bot.py
+++ b/.github/bot.py
@@ -24,8 +24,7 @@ def get_caption():
     )
     return msg
 
-async def send_telegram_message():
-    files = sys.argv[1]
+async def send_telegram_message(files):
     async with TelegramClient(StringSession(BOT_CI_SESSION), api_id=API_ID, api_hash=API_HASH) as client:
         await client.start(bot_token=BOT_TOKEN)
         print("[+] Caption: ")
@@ -41,6 +40,7 @@ async def send_telegram_message():
 
 if __name__ == '__main__':
     try:
-        asyncio.run(send_telegram_message())
+        apk_files = sys.argv[1:]
+        asyncio.run(send_telegram_message(apk_files))
     except Exception as e:
         print(f"[-] An error occurred: {e}")

--- a/.github/workflows/auto-preview-dev.yml
+++ b/.github/workflows/auto-preview-dev.yml
@@ -66,7 +66,7 @@ jobs:
 
       # 7. 构建 APK
       - name: Build Dev Release APK
-        run: ./gradlew assembleUnstableRelease
+        run: ./gradlew assembleOnlineUnstableRelease assembleOfflineUnstableRelease
 
       # 8. 上传 APK 作为 Artifact
       #    将所有构建产物打包到一个ZIP文件中
@@ -75,7 +75,9 @@ jobs:
         with:
           # Artifact 的名称，包含提交哈希以便于识别
           name: dev-apk-${{ steps.commit_sha.outputs.SHORT_SHA }}
-          # 需要上传的文件的路径 (使用通配符匹配所有APK)
-          path: app/build/outputs/apk/Unstable/release/*.apk
+          # 需要上传的文件的路径
+          path: |
+            app/build/outputs/apk/onlineUnstable/release/*.apk
+            app/build/outputs/apk/offlineUnstable/release/*.apk
           # 设置产物的保留天数
           retention-days: 15

--- a/.github/workflows/auto-preview-release.yml
+++ b/.github/workflows/auto-preview-release.yml
@@ -61,44 +61,40 @@ jobs:
           echo "keyPassword=${{ secrets.SIGNING_KEY_PASSWORD }}" >> keystore.properties
           echo "storePassword=${{ secrets.SIGNING_STORE_PASSWORD }}" >> keystore.properties
 
-      # Step 7: Build the APK
-      - name: Build Preview Release APK
-        run: ./gradlew assemblePreviewRelease
+      # Step 7: Build both Preview Release APKs
+      - name: Build Preview Release APKs
+        run: ./gradlew assembleOnlinePreviewRelease assembleOfflinePreviewRelease
 
-      # Step 8: Find and rename the generated APK
-      - name: Find and Rename Preview APK
-        id: rename_apk
+      # Step 8: Find and Rename Preview APKs
+      - name: Find and Rename Preview APKs
+        id: rename_apks
         run: |
           PROJECT_NAME="InstallerX-Revived"
-          # Construct the version part of the filename (e.g., v1.2.4-a1b2c3d-alpha)
           VERSION_TAG="${{ steps.version.outputs.VNEW_VERSION }}-${{ steps.commit_sha.outputs.SHORT_SHA }}-alpha"
-          APK_DIR="app/build/outputs/apk/Preview/release/"
-          
-          # Find the original APK file path
-          ORIGINAL_APK_PATH=$(find "$APK_DIR" -maxdepth 1 -type f -name "*.apk")
 
-          # Error handling if APK is not found or multiple are found
-          if [ -z "$ORIGINAL_APK_PATH" ]; then
-            echo "ERROR: APK file not found in $APK_DIR!"
-            # List directory contents for easier debugging
+          ONLINE_APK_DIR="app/build/outputs/apk/onlinePreview/release/"
+          OFFLINE_APK_DIR="app/build/outputs/apk/offlinePreview/release/"
+
+          ONLINE_APK_PATH=$(find "$ONLINE_APK_DIR" -maxdepth 1 -type f -name "*.apk" | head -n 1)
+          OFFLINE_APK_PATH=$(find "$OFFLINE_APK_DIR" -maxdepth 1 -type f -name "*.apk" | head -n 1)
+
+          if [ -z "$ONLINE_APK_PATH" ] || [ -z "$OFFLINE_APK_PATH" ]; then
+            echo "ERROR: Could not find both APKs!"
             ls -R app/build/outputs/apk
             exit 1
-          elif [ $(echo "$ORIGINAL_APK_PATH" | wc -l) -ne 1 ]; then
-            echo "ERROR: Expected 1 APK file, but found multiple!"
-            echo "$ORIGINAL_APK_PATH"
-            exit 1
           fi
-          
-          # Define the new file name and path
-          NEW_APK_NAME="${PROJECT_NAME}-${VERSION_TAG}.apk"
-          NEW_APK_PATH="${APK_DIR}${NEW_APK_NAME}"
-          
-          echo "Found APK: $ORIGINAL_APK_PATH"
-          echo "Renaming to: $NEW_APK_PATH"
-          mv "$ORIGINAL_APK_PATH" "$NEW_APK_PATH"
-          
-          # Output the new path for subsequent steps
-          echo "new_path=${NEW_APK_PATH}" >> $GITHUB_OUTPUT
+
+          NEW_ONLINE_APK_NAME="${PROJECT_NAME}-${VERSION_TAG}-online.apk"
+          NEW_OFFLINE_APK_NAME="${PROJECT_NAME}-${VERSION_TAG}-offline.apk"
+
+          NEW_ONLINE_APK_PATH="${ONLINE_APK_DIR}${NEW_ONLINE_APK_NAME}"
+          NEW_OFFLINE_APK_PATH="${OFFLINE_APK_DIR}${NEW_OFFLINE_APK_NAME}"
+
+          mv "$ONLINE_APK_PATH" "$NEW_ONLINE_APK_PATH"
+          mv "$OFFLINE_APK_PATH" "$NEW_OFFLINE_APK_PATH"
+
+          echo "online_apk=${NEW_ONLINE_APK_PATH}" >> $GITHUB_OUTPUT
+          echo "offline_apk=${NEW_OFFLINE_APK_PATH}" >> $GITHUB_OUTPUT
 
       # Step 9: Delete the old alpha release and its corresponding git tag
       - name: Delete old alpha release and tag
@@ -163,7 +159,7 @@ jobs:
           echo "--- Generated Changelog for Release Body ---"
           echo -e "${CHANGELOG_BODY_OUTPUT}${CHANGELOG_LINK_OUTPUT}"
 
-      # Step 11: Create a new GitHub pre-release
+      # Step 11: Create Latest Alpha Pre-Release with two APKs
       - name: Create Latest Alpha Pre-Release
         uses: softprops/action-gh-release@v2
         with:
@@ -172,21 +168,19 @@ jobs:
           target_commitish: ${{ github.sha }}
           body: |
             ## 这是自动构建的最新 Alpha 测试版。
-            
-            - **这是一个预发布版本，并非为生产环境准备就绪。** 它仅用于测试和评估目的。请勿在实际生产环境中使用此版本。
-            - 我们非常鼓励您分享您的看法！如果您有任何反馈、建议，或者遇到了任何问题，请随时在GitHub上提交Issue或Pull Request。
+            - **这是一个预发布版本，并非为生产环境准备就绪。**
+            - 我们非常鼓励您分享您的看法！
             
             ## This is an automatically built latest Alpha pre-release.
-            - **This is a pre-release version and is not intended for production use.** It is for testing and evaluation purposes only. Please do not use this version in a production environment.
-            - We highly encourage you to share your thoughts! If you have any feedback, suggestions, or encounter any issues, please feel free to submit an Issue or Pull Request on GitHub.
+            - **This is a pre-release version and is not intended for production use.**
             
             **更新日志（Changelog）:**
-            
             ${{ steps.changelog.outputs.changelog_body }}${{ steps.changelog.outputs.changelog_full_link }}
-
           prerelease: true
-          # Use the exact path of the renamed APK
-          files: ${{ steps.rename_apk.outputs.new_path }}
+          files: |
+            ${{ steps.rename_apks.outputs.online_apk }}
+            ${{ steps.rename_apks.outputs.offline_apk }}
+      
 
       # Step 12: Upload the APK to Telegram
       - name: Upload to Telegram
@@ -197,9 +191,6 @@ jobs:
           CHAT_ID: ${{ secrets.CHAT_ID }}
           BOT_CI_SESSION: ${{ secrets.BOT_CI_SESSION }}
           COMMIT_MESSAGE: ${{ steps.changelog.outputs.changelog_body }}
-          # Pass the renamed APK path to the script as an environment variable
-          APK_PATH: ${{ steps.rename_apk.outputs.new_path }}
         run: |
           pip3 install telethon
-          # Use the APK_PATH environment variable directly
-          python3 .github/bot.py "$APK_PATH"
+          python3 .github/bot.py "${{ steps.rename_apks.outputs.online_apk }}" "${{ steps.rename_apks.outputs.offline_apk }}"

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -51,35 +51,30 @@ jobs:
           storePassword=${{ secrets.SIGNING_STORE_PASSWORD }}
           EOF
 
-      - name: Build Stable Release APK
-        run: ./gradlew assembleStableRelease
+      - name: Build Stable Release APKs
+        run: ./gradlew assembleOnlineStableRelease assembleOfflineStableRelease
 
-      - name: Find and Rename Universal APK
+      - name: Find and Rename Universal APKs
         id: rename_apk
         run: |
           PROJECT_NAME="InstallerX-Revived"
           VERSION_TAG="${{ inputs.version_tag }}"
-          APK_DIR="app/build/outputs/apk/Stable/release/"
-          
-          ORIGINAL_APK_PATH=$(find "$APK_DIR" -maxdepth 1 -type f -name "*.apk")
+          for FLAVOR in online offline; do
+            APK_DIR="app/build/outputs/apk/${FLAVOR}Stable/release/"
+            ORIGINAL_APK=$(find "$APK_DIR" -maxdepth 1 -type f -name "*.apk" | head -n 1)
 
-          if [ -z "$ORIGINAL_APK_PATH" ]; then
-            echo "ERROR: Universal APK file not found in $APK_DIR!"
-            # List directory contents for easier debugging
-            ls -R app/build/outputs/apk
-            exit 1
-          elif [ $(echo "$ORIGINAL_APK_PATH" | wc -l) -ne 1 ]; then
-            echo "ERROR: Expected 1 APK file, but found multiple!"
-            echo "$ORIGINAL_APK_PATH"
-            exit 1
-          fi
-          
-          NEW_APK_NAME="${PROJECT_NAME}-${VERSION_TAG}.apk"
-          NEW_APK_PATH="${APK_DIR}${NEW_APK_NAME}"
-          
-          echo "Found APK: $ORIGINAL_APK_PATH"
-          echo "Renaming to: $NEW_APK_PATH"
-          mv "$ORIGINAL_APK_PATH" "$NEW_APK_PATH"
+            if [ -z "$ORIGINAL_APK" ]; then
+              echo "ERROR: APK not found in $APK_DIR!"
+              ls -R app/build/outputs/apk
+              exit 1
+            fi
+
+            NEW_APK_NAME="${PROJECT_NAME}-${FLAVOR}-${VERSION_TAG}.apk"
+            NEW_APK_PATH="${APK_DIR}${NEW_APK_NAME}"
+
+            echo "Renaming $ORIGINAL_APK -> $NEW_APK_PATH"
+            mv "$ORIGINAL_APK" "$NEW_APK_PATH"
+          done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -88,16 +83,6 @@ jobs:
           tag_name: ${{ inputs.version_tag }}
           body: ${{ inputs.changelog }}
           prerelease: false
-          files: app/build/outputs/apk/Stable/release/InstallerX-Revived-${{ inputs.version_tag }}.apk
-
-      - name: Upload to Telegram
-        env:
-          API_ID: ${{ secrets.API_ID }}
-          API_HASH: ${{ secrets.API_HASH }}
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-          CHAT_ID: ${{ secrets.CHAT_ID }}
-          BOT_CI_SESSION: ${{ secrets.BOT_CI_SESSION }}
-        run: |
-          pip3 install telethon
-          APK_PATH=$(find ./app/build/outputs/apk/Stable/release -name "*.apk")
-          python3 .github/bot.py "$APK_PATH"
+          files: |
+            app/build/outputs/apk/onlineStable/release/InstallerX-Revived-online-${{ inputs.version_tag }}.apk
+            app/build/outputs/apk/offlineStable/release/InstallerX-Revived-offline-${{ inputs.version_tag }}.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,9 +87,21 @@ android {
         }
     }
 
-    flavorDimensions += "level"
+    flavorDimensions.addAll(listOf("connectivity", "level"))
 
     productFlavors {
+        create("online") {
+            dimension = "connectivity"
+            // Set the build config field for this flavor.
+            buildConfigField("boolean", "INTERNET_ACCESS_ENABLED", "true")
+        }
+
+        create("offline") {
+            dimension = "connectivity"
+            // Set the build config field for this flavor.
+            buildConfigField("boolean", "INTERNET_ACCESS_ENABLED", "false")
+        }
+
         create("Unstable") {
             dimension = "level"
             isDefault = true
@@ -104,21 +116,13 @@ android {
         }
     }
 
-    /*    val isReleaseBuild = gradle.startParameter.taskNames.any {
-            it.contains("Release", ignoreCase = true)
-        }
-
-        splits {
-            abi {
-                isEnable = isReleaseBuild
-                reset()
-                include("arm64-v8a", "x86_64")
-                isUniversalApk = false
-            }
-        }*/
-
     applicationVariants.all {
-        val level = when (flavorName) {
+        val variant = this
+
+        val levelFlavor = variant.productFlavors.find { it.dimension == "level" }
+
+
+        val level = when (levelFlavor?.name) {
             "Unstable" -> 0
             "Preview" -> 1
             "Stable" -> 2

--- a/app/src/main/java/com/rosan/installer/App.kt
+++ b/app/src/main/java/com/rosan/installer/App.kt
@@ -1,6 +1,8 @@
 package com.rosan.installer
 
 import android.app.Application
+import com.rosan.installer.build.Level
+import com.rosan.installer.build.RsConfig
 import com.rosan.installer.di.init.appModules
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -11,7 +13,7 @@ class App : Application() {
     override fun onCreate() {
         CrashHandler.init()
         super.onCreate()
-        if (BuildConfig.DEBUG) {
+        if (RsConfig.LEVEL == Level.PREVIEW || RsConfig.isDebug) {
             Timber.plant(Timber.DebugTree())
         }
         startKoin {

--- a/app/src/main/java/com/rosan/installer/build/RsConfig.kt
+++ b/app/src/main/java/com/rosan/installer/build/RsConfig.kt
@@ -8,6 +8,8 @@ import com.rosan.installer.BuildConfig
 object RsConfig {
     val LEVEL: Level = getLevel()
     val isDebug: Boolean = BuildConfig.DEBUG
+    val isInternetAccessEnabled
+        get() = BuildConfig.INTERNET_ACCESS_ENABLED
 
     private fun getLevel(): Level {
         return when (BuildConfig.BUILD_LEVEL) {

--- a/app/src/main/java/com/rosan/installer/data/installer/model/exception/ResolvedFailedNoInternetAccessException.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/exception/ResolvedFailedNoInternetAccessException.kt
@@ -1,0 +1,7 @@
+package com.rosan.installer.data.installer.model.exception
+
+class ResolvedFailedNoInternetAccessException : Exception {
+    constructor() : super()
+
+    constructor(message: String?) : super(message)
+}

--- a/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/DialogInnerWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/installer/dialog/DialogInnerWidget.kt
@@ -65,12 +65,11 @@ fun dialogGenerateParams(
         )
 
         is DialogViewState.InstallRetryDowngradeUsingUninstall -> installingDialog(installer, viewModel)
-        // is DialogViewState. -> installingDialog(installer, viewModel)
         is DialogViewState.UninstallReady -> uninstallReadyDialog(viewModel)
         is DialogViewState.UninstallSuccess -> uninstallSuccessDialog(viewModel)
         is DialogViewState.UninstallFailed -> uninstallFailedDialog(installer, viewModel)
         is DialogViewState.Uninstalling -> uninstallingDialog(installer, viewModel)
         is DialogViewState.UninstallResolveFailed -> uninstallFailedDialog(installer, viewModel)
         // when is exhaustive, so no need to handle the else case
-        //else -> readyDialog(installer, viewModel)
+        // else -> readyDialog(installer, viewModel)
     }

--- a/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/home/HomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/settings/preferred/subpage/home/HomePage.kt
@@ -116,7 +116,7 @@ fun HomePage(
  * @author iamr0s
  */
 @Composable
-fun StatusWidget() {
+private fun StatusWidget() {
     val containerColor = when (RsConfig.LEVEL) {
         Level.STABLE -> MaterialTheme.colorScheme.primaryContainer
         Level.PREVIEW -> MaterialTheme.colorScheme.secondaryContainer
@@ -128,6 +128,9 @@ fun StatusWidget() {
         Level.PREVIEW -> MaterialTheme.colorScheme.onSecondaryContainer
         Level.UNSTABLE -> MaterialTheme.colorScheme.onTertiaryContainer
     }
+
+    val internetAccessHint = if (RsConfig.isInternetAccessEnabled) stringResource(R.string.internet_access_enabled)
+    else stringResource(R.string.internet_access_disabled)
 
     val level = when (RsConfig.LEVEL) {
         Level.STABLE -> stringResource(id = R.string.stable)
@@ -164,7 +167,7 @@ fun StatusWidget() {
             Box(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
-                    text = "$level ${RsConfig.VERSION_NAME} (${RsConfig.VERSION_CODE})",
+                    text = "$internetAccessHint$level ${RsConfig.VERSION_NAME} (${RsConfig.VERSION_CODE})",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }

--- a/app/src/main/java/com/rosan/installer/util/ThrowableUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/ThrowableUtil.kt
@@ -37,6 +37,8 @@ import com.rosan.installer.data.app.model.exception.InstallFailedVerificationFai
 import com.rosan.installer.data.app.model.exception.InstallFailedVerificationTimeoutException
 import com.rosan.installer.data.app.model.exception.InstallFailedVersionDowngradeException
 import com.rosan.installer.data.app.model.exception.UninstallFailedHyperOSSystemAppException
+import com.rosan.installer.data.installer.model.exception.ResolveException
+import com.rosan.installer.data.installer.model.exception.ResolvedFailedNoInternetAccessException
 import com.rosan.installer.data.recycle.model.exception.AppProcessNotWorkException
 import com.rosan.installer.data.recycle.model.exception.DhizukuNotWorkException
 import com.rosan.installer.data.recycle.model.exception.RootNotWorkException
@@ -51,8 +53,10 @@ import com.rosan.installer.data.recycle.model.exception.ShizukuNotWorkException
  * @author iamr0s wxxsfxyzm
  * @return R.string 的资源 ID。
  */
-private fun Throwable.getStringResourceId(): Int {
-    return when (this) {
+private fun Throwable.getStringResourceId() =
+    when (this) {
+        is ResolveException -> R.string.exception_resolve_failed
+        is ResolvedFailedNoInternetAccessException -> R.string.exception_resolve_failed_no_internet_access
         is AnalyseFailedAllFilesUnsupportedException -> R.string.exception_analyse_failed_all_files_unsupported
         is InstallFailedAlreadyExistsException -> R.string.exception_install_failed_already_exists
         is InstallFailedBlacklistedPackageException -> R.string.exception_install_failed_blacklisted_package
@@ -92,7 +96,6 @@ private fun Throwable.getStringResourceId(): Int {
         is AppProcessNotWorkException -> R.string.exception_app_process_not_work
         else -> R.string.exception_install_failed_unknown
     }
-}
 
 /**
  * [公开API - Composable]

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,6 +19,9 @@
     <string name="about_detail">关于 InstallerX</string>
     <string name="get_update_detail">检查软件更新和新功能</string>
 
+    <string name="internet_access_enabled">联网</string>
+    <string name="internet_access_disabled">离线</string>
+
     <string name="stable">正式版</string>
     <string name="preview">预览版</string>
     <string name="unstable">测试版</string>
@@ -254,6 +257,8 @@
     <string name="installer_file_path">路径：%1$s</string>
 
     <string name="exception_install_failed_unknown">未知错误</string>
+    <string name="exception_resolve_failed">URI解析失败</string>
+    <string name="exception_resolve_failed_no_internet_access">该版本无法访问互联网，要使用此功能，请安装支持联网的版本。</string>
     <string name="exception_analyse_failed_all_files_unsupported">不支持的文件格式</string>
     <string name="exception_install_failed_already_exists">应用已安装（包名相同、版本相同），请先卸载再安装</string>
     <string name="exception_install_failed_blacklisted_package">你不允许该应用的安装！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="get_update">Get update</string>
     <string name="get_update_detail">Check for software updates and new features.</string>
 
+    <string name="internet_access_enabled">Online</string>
+    <string name="internet_access_disabled">Offline</string>
+
     <string name="stable">Stable</string>
     <string name="preview">Preview</string>
     <string name="unstable">Unstable</string>
@@ -263,6 +266,8 @@
     <string name="installer_file_path">Path: %1$s</string>
 
     <string name="exception_install_failed_unknown">Unknown error</string>
+    <string name="exception_resolve_failed">Resolve URI failed</string>
+    <string name="exception_resolve_failed_no_internet_access">This version cannot access Internet, to use this feature, reinstall another version.</string>
     <string name="exception_analyse_failed_all_files_unsupported">File not supported</string>
     <string name="exception_install_failed_already_exists">This app version is already installed, please uninstall and try again</string>
     <string name="exception_install_failed_blacklisted_package">You don\'t allow installation of the app!</string>

--- a/app/src/online/AndroidManifest.xml
+++ b/app/src/online/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- only in online flavor -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+</manifest>


### PR DESCRIPTION
This commit introduces separate online and offline build flavors for the application.

Key changes:
- Added `connectivity` flavor dimension with `online` and `offline` product flavors in `app/build.gradle.kts`.
- The `INTERNET_ACCESS_ENABLED` build config field is set accordingly for each flavor.
- Introduced `online/AndroidManifest.xml` to include `android.permission.INTERNET` only for the online flavor.
- Modified `RsConfig.kt` to expose `isInternetAccessEnabled` based on the new build config field.
- Updated `ActionHandler.kt` to:
    - Handle `text/plain` intents by attempting to download from URLs if internet access is enabled.
    - Added `downloadAndCacheHttpUri` to download and cache files from HTTP/HTTPS URLs, showing progress.
    - Throws `ResolvedFailedNoInternetAccessException` if internet access is required but disabled.
- Added new string resources for internet access status and related error messages.
- Updated `HomePage.kt` to display internet access status.
- Modified GitHub Actions workflows (`auto-preview-release.yml`, `auto-preview-dev.yml`, `manual-stable-release.yml`) to build and handle both online and offline APKs.
- Updated `.github/bot.py` to handle multiple APK files for Telegram uploads.
- Enabled Timber logging for `PREVIEW` builds in `App.kt`.