### PR TITLE
fix(installer): use correct data source for file installation

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/app/model/impl/installer/IBinderInstallerRepoImpl.kt
@@ -294,7 +294,7 @@ abstract class IBinderInstallerRepoImpl : InstallerRepo, KoinComponent {
         config: ConfigEntity, entity: InstallEntity, extra: InstallExtraInfoEntity, session: Session
     ) {
         // Get DataEntity from InstallEntity
-        val dataEntity = entity.data.getSourceTop() as? DataEntity.FileEntity
+        val dataEntity = entity.data as? DataEntity.FileEntity
             ?: throw IOException("DataEntity is not a valid FileEntity for installation.")
 
         // Get originalUri from DataEntity
@@ -321,7 +321,7 @@ abstract class IBinderInstallerRepoImpl : InstallerRepo, KoinComponent {
                 throw e
             }
         } else {
-            // --- Condition B: Cache File ---
+            // --- Condition 2: Cache File ---
             // Use path directly from DataEntity
             Timber.d("Streaming from cache file path: ${dataEntity.path}")
             val file = File(dataEntity.path)


### PR DESCRIPTION
This commit ensures that the installation process uses the correct data source when installing from a file. Previously, it was attempting to get the top source, which might not be the actual file entity.

Additionally, a comment was updated from "Condition B" to "Condition 2" for clarity.