### PR TITLE
Refactor README and make docs folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # InstallerX Revived (Community Edition)
 
-[![中文文档](https://img.shields.io/badge/README_%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-239120?style=flat-square)](./README_CN.md)[![README en español](https://img.shields.io/badge/README_ES-0077b5?style=flat-square)](./README_ES.md)
+**English** | [简体中文](README_CN.md) | [Español](README_ES.md)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)[![Latest Release](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?label=Stable)](https://github.com/wxxsfxyzm/InstallerX/releases/latest)[![Prerelease](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?include_prereleases&label=Beta)](https://github.com/wxxsfxyzm/InstallerX/releases)[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white)](https://t.me/installerx_revived)
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -1,5 +1,7 @@
 # InstallerX Revived (Community Edition)
 
+[English](README.md) | **简体中文** | [Español](README_ES.md)
+
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)[![Latest Release](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?label=稳定版)](https://github.com/wxxsfxyzm/InstallerX/releases/latest)[![Prerelease](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?include_prereleases&label=测试版)](https://github.com/wxxsfxyzm/InstallerX/releases)[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white)](https://t.me/installerx_revived)
 
 - 这是一个由社区维护的分支版本， [原项目](https://github.com/iamr0s/InstallerX)已被作者归档。

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -1,5 +1,7 @@
 # InstallerX Revived (Edición Comunitaria)
 
+[English](README.md) | [简体中文](README_CN.md) | **Español**
+
 [![Licencia: GPL v3](https://img.shields.io/badge/Licencia-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)[![Última versión](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?label=Estable)](https://github.com/wxxsfxyzm/InstallerX/releases/latest)[![Vista previa](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?include_prereleases&label=Pruebas)](https://github.com/wxxsfxyzm/InstallerX/releases)[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white)](https://t.me/installerx_revived)
 
 - Esta es una versión mantenida por la comunidad. El [proyecto original](https://github.com/iamr0s/InstallerX) fue archivado por el autor.


### PR DESCRIPTION
This PR removes the language badges in the README and replaces them with something simpler and more obvious that will probably be clearer to the user.

The docs folder has also been created, where all relevant project documents are expected to be stored, such as new versions of the README or any other documentation that may be added.

Open to changing anything as always :3