### PR TITLE
fix(installer): support `CONFIRM_PERMISSIONS` intent handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,7 @@
 
             <intent-filter android:priority="10">
                 <action android:name="android.content.pm.action.CONFIRM_INSTALL" />
+                <action android:name="android.content.pm.action.CONFIRM_PERMISSIONS" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
@@ -49,6 +49,7 @@ class InstallerActivity : ComponentActivity(), KoinComponent {
     companion object {
         const val KEY_ID = "installer_id"
         private const val ACTION_CONFIRM_INSTALL = "android.content.pm.action.CONFIRM_INSTALL"
+        private const val ACTION_CONFIRM_PERMISSIONS = "android.content.pm.action.CONFIRM_PERMISSIONS"
     }
 
     private val appDataStore: AppDataStore by inject()
@@ -112,7 +113,7 @@ class InstallerActivity : ComponentActivity(), KoinComponent {
         permissionManager.requestEssentialPermissions(
             onGranted = {
                 Timber.d("All essential permissions are granted.")
-                if (intent.action == ACTION_CONFIRM_INSTALL) {
+                if (intent.action == ACTION_CONFIRM_INSTALL || intent.action == ACTION_CONFIRM_PERMISSIONS) {
                     val sessionId = intent.getIntExtra(PackageInstaller.EXTRA_SESSION_ID, -1)
                     if (sessionId != -1) {
                         Timber.d("onCreate: Dispatching resolveConfirmInstall for session $sessionId")
@@ -168,7 +169,7 @@ class InstallerActivity : ComponentActivity(), KoinComponent {
         super.onNewIntent(intent)
         restoreInstaller()
 
-        if (intent.action == ACTION_CONFIRM_INSTALL) {
+        if (intent.action == ACTION_CONFIRM_INSTALL || intent.action == ACTION_CONFIRM_PERMISSIONS) {
             val sessionId = intent.getIntExtra(PackageInstaller.EXTRA_SESSION_ID, -1)
             if (sessionId != -1) {
                 Timber.d("onNewIntent: Dispatching resolveConfirmInstall for session $sessionId")


### PR DESCRIPTION
This PR adds support for the `CONFIRM_PERMISSIONS` intent action, allowing the installer to handle install sessions on Android 8/9.

Fixes #409