### PR TITLE
Fix: Corrected broken links in README_JA.md

### DIFF
--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -1,6 +1,6 @@
 # InstallerX Revived (Community Edition)
 
-[English](README.md) | [简体中文](README_CN.md) | [Español](README_ES.md) | **日本語** | [日本語](README_JA.md)
+[English](README.md) | [简体中文](README_CN.md) | [Español](README_ES.md) | **日本語** | [Deutsch](README_DE.md)
 
 [![ライセンス: GPL v3](https://img.shields.io/badge/ライセンス-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)[![安定版](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?label=安定版)](https://github.com/wxxsfxyzm/InstallerX/releases/latest)[![ベータ版](https://img.shields.io/github/v/release/wxxsfxyzm/InstallerX?include_prereleases&label=ベータ版)](https://github.com/wxxsfxyzm/InstallerX/releases)[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?logo=telegram&logoColor=white)](https://t.me/installerx_revived)
 


### PR DESCRIPTION
The link from README_JA.md to README_DE.md was incorrect and has been corrected.