### PR TITLE
fix(ui): prevent log shift when installation completes

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/installer/sheetcontent/InstallModuleContent.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/installer/sheetcontent/InstallModuleContent.kt
@@ -60,9 +60,13 @@ fun InstallModuleContent(
 
     // Coroutine to auto-scroll to the bottom as new lines are added,
     // but ONLY if the installation is not yet finished.
-    LaunchedEffect(outputLines.size) {
-        if (!isFinished && outputLines.isNotEmpty()) {
-            lazyListState.animateScrollToItem(index = outputLines.size - 1)
+    LaunchedEffect(outputLines.size, isFinished) {
+        if (outputLines.isNotEmpty()) {
+            if (!isFinished) {
+                lazyListState.animateScrollToItem(index = outputLines.size - 1)
+            } else {
+                lazyListState.scrollToItem(index = outputLines.size - 1)
+            }
         }
     }
 


### PR DESCRIPTION
Fix module installer log scrolling so that the last line stays visible after installation. During installation, logs auto-scroll smoothly as before; after completion, the last line is immediately scrolled into view to handle LazyColumn layout changes caused by the bottom button. Manual scrolling is preserved, and no functional changes are made.