### PR TITLE
feat(ui): enable haze blur effect for Android 11 and below

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/NewAllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/NewAllPage.kt
@@ -107,6 +107,7 @@ fun NewAllPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/edit/NewEditPage.kt
@@ -199,6 +199,7 @@ fun NewEditPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/main/MainPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/main/MainPage.kt
@@ -132,6 +132,7 @@ fun MainPage(navController: NavController, preferredViewModel: PreferredViewMode
                         modifier = hazeState?.let {
                             Modifier.hazeEffect(hazeState) {
                                 style = hazeStyle
+                                blurEnabled = true
                                 blurRadius = 30.dp
                                 noiseFactor = 0f
                             }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
@@ -144,6 +144,7 @@ fun NewPreferredPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/home/NewHomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/home/NewHomePage.kt
@@ -87,6 +87,7 @@ fun NewHomePage(
                     modifier = topBarHazeState?.let {
                         Modifier.hazeEffect(it) {
                             style = hazeStyle
+                            blurEnabled = true
                             blurRadius = 30.dp
                             noiseFactor = 0f
                         }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/NewInstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/NewInstallerGlobalSettingsPage.kt
@@ -101,6 +101,7 @@ fun NewInstallerGlobalSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/NewUninstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/installer/NewUninstallerGlobalSettingsPage.kt
@@ -105,6 +105,7 @@ fun NewUninstallerGlobalSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/lab/NewLabPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/lab/NewLabPage.kt
@@ -85,6 +85,7 @@ fun NewLabPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
@@ -139,6 +139,7 @@ fun NewThemeSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(it) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/UpdateLoadingIndicator.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/setting/UpdateLoadingIndicator.kt
@@ -72,7 +72,9 @@ fun UpdateLoadingIndicator(
                             blurRadius = 25.dp,
                             noiseFactor = 0f
                         )
-                    )
+                    ) {
+                        blurEnabled = true
+                    }
                 } ?: Modifier)
                 .background(Color.Black.copy(alpha = 0.3f))
                 .clickable(

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/MiuixSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/MiuixSettingsPage.kt
@@ -330,6 +330,7 @@ private fun SettingsCompactLayout(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
@@ -81,6 +81,7 @@ fun MiuixAllPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/edit/MiuixEditPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/edit/MiuixEditPage.kt
@@ -133,6 +133,7 @@ fun MiuixEditPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
@@ -84,6 +84,7 @@ fun MiuixPreferredPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/home/MiuixHomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/home/MiuixHomePage.kt
@@ -125,6 +125,7 @@ fun MiuixHomePage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/home/ossLicensePage/MiuixOpenSourceLicensePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/home/ossLicensePage/MiuixOpenSourceLicensePage.kt
@@ -42,6 +42,7 @@ fun MiuixOpenSourceLicensePage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/installer/MiuixInstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/installer/MiuixInstallerGlobalSettingsPage.kt
@@ -78,6 +78,7 @@ fun MiuixInstallerGlobalSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/installer/MiuixUninstallerGlobalSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/installer/MiuixUninstallerGlobalSettingsPage.kt
@@ -83,6 +83,7 @@ fun MiuixUninstallerGlobalSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/lab/MiuixLabPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/lab/MiuixLabPage.kt
@@ -77,6 +77,7 @@ fun MiuixLabPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
@@ -79,6 +79,7 @@ fun MiuixThemeSettingsPage(
                 modifier = hazeState?.let {
                     Modifier.hazeEffect(hazeState) {
                         style = hazeStyle
+                        blurEnabled = true
                         blurRadius = 30.dp
                         noiseFactor = 0f
                     }


### PR DESCRIPTION
Explicitly set `blurEnabled = true` in all `hazeEffect` modifiers to enable the RenderScript-based blurring for devices running Android 11 or lower.

https://chrisbanes.github.io/haze/latest/platforms/#android-11-and-below