### PR TITLE
fix: biometric auth on Android 8.x

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -141,7 +141,7 @@
             android:name=".ui.activity.BiometricsAuthenticationActivity"
             android:exported="false"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.Installer.Translucent"
+            android:theme="@style/Theme.Installer.Translucent.AppCompat"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true" />
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,4 +2,12 @@
 <resources>
 
     <style name="Theme.Installer" parent="android:Theme.Material.NoActionBar" />
+
+    <style name="Theme.Installer.Translucent.AppCompat" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,4 +8,12 @@
         <!--沉浸状态栏和导航栏-->
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
+
+    <style name="Theme.Installer.Translucent.AppCompat" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Use `AppCompat` theme for `BiometricsAuthenticationActivity` to support the legacy fingerprint dialog on versions prior to Android 9.

Fixes #392