### PR TITLE
feat(ui): add stability warning for blur effect on Android 11 and below

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredViewModel.kt
@@ -769,7 +769,7 @@ class PreferredViewModel(
             val useDynColorFollowPkgIconForLiveActivityFlow =
                 appDataStore.getBoolean(AppDataStore.LIVE_ACTIVITY_DYN_COLOR_FOLLOW_PKG_ICON, false)
             val useBlurFlow =
-                appDataStore.getBoolean(AppDataStore.UI_USE_BLUR, true)
+                appDataStore.getBoolean(AppDataStore.UI_USE_BLUR, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
 
             combine(
                 authorizerFlow,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
@@ -60,6 +60,7 @@ import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.page.main.settings.preferred.PreferredViewAction
 import com.rosan.installer.ui.page.main.settings.preferred.PreferredViewModel
 import com.rosan.installer.ui.page.main.widget.card.ColorSwatchPreview
+import com.rosan.installer.ui.page.main.widget.dialog.BlurWarningDialog
 import com.rosan.installer.ui.page.main.widget.dialog.HideLauncherIconWarningDialog
 import com.rosan.installer.ui.page.main.widget.setting.AppBackButton
 import com.rosan.installer.ui.page.main.widget.setting.BaseWidget
@@ -92,6 +93,7 @@ fun NewThemeSettingsPage(
     var showHideLauncherIconDialog by remember { mutableStateOf(false) }
     var showPaletteDialog by remember { mutableStateOf(false) }
     var showThemeModeDialog by remember { mutableStateOf(false) }
+    var showBlurWarningDialog by remember { mutableStateOf(false) }
 
     if (showPaletteDialog) {
         PaletteStyleDialog(
@@ -125,6 +127,15 @@ fun NewThemeSettingsPage(
         onConfirm = {
             showHideLauncherIconDialog = false
             viewModel.dispatch(PreferredViewAction.ChangeShowLauncherIcon(false))
+        }
+    )
+
+    BlurWarningDialog(
+        show = showBlurWarningDialog,
+        onDismiss = { showBlurWarningDialog = false },
+        onConfirm = {
+            showBlurWarningDialog = false
+            viewModel.dispatch(PreferredViewAction.SetUseBlur(true))
         }
     )
 
@@ -223,7 +234,13 @@ fun NewThemeSettingsPage(
                             title = stringResource(R.string.theme_settings_use_blur),
                             description = stringResource(R.string.theme_settings_use_blur_desc),
                             checked = state.useBlur,
-                            onCheckedChange = { viewModel.dispatch(PreferredViewAction.SetUseBlur(it)) }
+                            onCheckedChange = { isChecked ->
+                                if (isChecked && Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+                                    showBlurWarningDialog = true
+                                } else {
+                                    viewModel.dispatch(PreferredViewAction.SetUseBlur(isChecked))
+                                }
+                            }
                         )
                     }
                     item {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
@@ -337,3 +337,33 @@ fun UninstallPackageDialog(
         }
     )
 }
+
+/**
+ * A dialog to warn the user about unstable blur effects on Android 11 and below.
+ */
+@Composable
+fun BlurWarningDialog(
+    show: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    if (show) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(text = stringResource(R.string.warning)) },
+            text = {
+                Text(text = stringResource(R.string.theme_settings_use_blur_warning))
+            },
+            confirmButton = {
+                TextButton(onClick = onConfirm) {
+                    Text(text = stringResource(R.string.confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
@@ -35,6 +35,7 @@ import com.rosan.installer.ui.page.main.settings.preferred.PreferredViewAction
 import com.rosan.installer.ui.page.main.settings.preferred.PreferredViewModel
 import com.rosan.installer.ui.page.main.widget.card.ColorSwatchPreview
 import com.rosan.installer.ui.page.miuix.widgets.MiuixBackButton
+import com.rosan.installer.ui.page.miuix.widgets.MiuixBlurWarningDialog
 import com.rosan.installer.ui.page.miuix.widgets.MiuixHideLauncherIconWarningDialog
 import com.rosan.installer.ui.page.miuix.widgets.MiuixSwitchWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixThemeEngineWidget
@@ -63,6 +64,7 @@ fun MiuixThemeSettingsPage(
     val hazeState = if (state.useBlur) remember { HazeState() } else null
     val hazeStyle = rememberMiuixHazeStyle()
     val showHideLauncherIconDialog = remember { mutableStateOf(false) }
+    val showBlurWarningDialog = remember { mutableStateOf(false) }
 
     MiuixHideLauncherIconWarningDialog(
         showState = showHideLauncherIconDialog,
@@ -70,6 +72,15 @@ fun MiuixThemeSettingsPage(
         onConfirm = {
             showHideLauncherIconDialog.value = false
             viewModel.dispatch(PreferredViewAction.ChangeShowLauncherIcon(false))
+        }
+    )
+
+    MiuixBlurWarningDialog(
+        showState = showBlurWarningDialog,
+        onDismiss = { showBlurWarningDialog.value = false },
+        onConfirm = {
+            showBlurWarningDialog.value = false
+            viewModel.dispatch(PreferredViewAction.SetUseBlur(true))
         }
     )
 
@@ -129,7 +140,13 @@ fun MiuixThemeSettingsPage(
                         title = stringResource(R.string.theme_settings_use_blur),
                         description = stringResource(R.string.theme_settings_use_blur_desc),
                         checked = state.useBlur,
-                        onCheckedChange = { viewModel.dispatch(PreferredViewAction.SetUseBlur(it)) }
+                        onCheckedChange = { isChecked ->
+                            if (isChecked && Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+                                showBlurWarningDialog.value = true
+                            } else {
+                                viewModel.dispatch(PreferredViewAction.SetUseBlur(isChecked))
+                            }
+                        }
                     )
                     MiuixSwitchWidget(
                         title = stringResource(R.string.theme_settings_miuix_custom_colors),

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixDialog.kt
@@ -514,3 +514,46 @@ fun MiuixUninstallPackageDialog(
         }
     )
 }
+
+/**
+ * A miuix-style dialog to warn the user about unstable blur effects on Android 11 and below.
+ */
+@Composable
+fun MiuixBlurWarningDialog(
+    showState: MutableState<Boolean>,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    SuperDialog(
+        show = showState,
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.warning),
+        content = {
+            Column {
+                Text(stringResource(R.string.theme_settings_use_blur_warning))
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    TextButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = onDismiss,
+                        text = stringResource(R.string.cancel)
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = onConfirm,
+                        text = stringResource(R.string.confirm),
+                        colors = ButtonDefaults.textButtonColorsPrimary()
+                    )
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -61,6 +61,7 @@
     <string name="theme_settings_use_expressive_ui_desc">使用全新 Material 3 Expressive 设计风格</string>
     <string name="theme_settings_use_blur">启用模糊</string>
     <string name="theme_settings_use_blur_desc">为应用启用模糊效果</string>
+    <string name="theme_settings_use_blur_warning">在 Android 11 及以下系统中，模糊效果不稳定并可能导致异常。如果出现问题，可能需要清除应用数据。是否继续启用？</string>
     <string name="theme_settings_google_ui_style">Google UI 风格</string>
     <string name="theme_settings_theme_mode">主题模式</string>
     <string name="theme_settings_theme_mode_desc">选择主题模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="theme_settings_use_expressive_ui_desc">Use the new M3 Expressive style</string>
     <string name="theme_settings_use_blur">Enable Blur</string>
     <string name="theme_settings_use_blur_desc">Enable blur for the app</string>
+    <string name="theme_settings_use_blur_warning">The blur effect may be unstable and cause unexpected issues on Android 11 and below. You may need to clear app data if problems occur. Do you want to continue?</string>
     <string name="theme_settings_google_ui_style">Google UI style</string>
     <string name="theme_settings_theme_mode">Theme Mode</string>
     <string name="theme_settings_theme_mode_desc">Select theme mode</string>


### PR DESCRIPTION
* Modified `PreferredViewModel` to disable blur by default on devices below Android 12.
* Implemented `BlurWarningDialog` and `MiuixBlurWarningDialog` to caution users about potential instability when enabling blur on older Android versions.
* Updated `NewThemeSettingsPage` and `MiuixThemeSettingsPage` to trigger the warning dialog when enabling blur on Android 11 or lower.

Resolves #454