### PR TITLE
fix: update foojay-resolver-convention plugin version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
最新的Gradle已经废除了IBM_SEMERU，但项目的 foojay-resolver-convention 0.8.0版本仍旧使用它，这导致了Android Studio 同步项目时出现错误，无法正常工作。此PR用于修复此问题

The latest Gradle has abolished IBM_SMERU, but the foojay-resolver-convention 0.8.0 version of the project still uses it, which causes errors when synchronizing the project with Android Studio and prevents it from working properly. This Pull Request is used to fix this issue