### PR TITLE
feat: add notification for installation analysis failure

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ForegroundInfoHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/installer/model/impl/installer/ForegroundInfoHandler.kt
@@ -470,7 +470,7 @@ class ForegroundInfoHandler(scope: CoroutineScope, installer: InstallerRepo) :
                 baseBuilder.addAction(0, getString(R.string.cancel), cancelIntent)
             }
 
-            is ProgressEntity.InstallResolvedFailed -> {
+            is ProgressEntity.InstallResolvedFailed, ProgressEntity.InstallAnalysedFailed -> {
                 contentTitle = getString(R.string.installer_resolve_failed)
                 shortText = getString(R.string.installer_live_channel_short_text_resolve_failed)
                 baseBuilder.setContentText(installer.error.getErrorMessage(context)).setOnlyAlertOnce(false)


### PR DESCRIPTION
Add a dedicated notification for when the installation analysis process fails, mirroring the existing behavior for resolution failures. This ensures the user is informed if the process stops during the analysis phase.