### PR TITLE
fix: remove premature APK pre-selection in MixedModuleZip flow

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/installer/sheetcontent/InstallChoiceContent.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/installer/sheetcontent/InstallChoiceContent.kt
@@ -572,20 +572,7 @@ private fun MixedModuleZip_InitialChoice(
                     MiuixNavigationItemWidget(
                         title = stringResource(R.string.installer_choice_install_as_app),
                         description = stringResource(R.string.installer_choice_install_as_app_desc),
-                        onClick = {
-                            analysisResults.flatMap { it.appEntities }
-                                .filter { it.app !is AppEntity.ModuleEntity }
-                                .forEach { entity ->
-                                    viewModel.dispatch(
-                                        InstallerViewAction.ToggleSelection(
-                                            packageName = entity.app.packageName,
-                                            entity = entity,
-                                            isMultiSelect = true
-                                        )
-                                    )
-                                }
-                            onSelectApk()
-                        }
+                        onClick = { onSelectApk() }
                     )
                 }
             }


### PR DESCRIPTION
When the user chose "Install as App" in the MIXED_MODULE_ZIP initial choice screen, all non-module entities were being pre-selected via ToggleSelection before entering APK_CHOICE mode. This caused the APK selection page to appear fully checked on entry, giving the user no meaningful choice.

The root cause: SelectionStrategy initializes all MIXED_MODULE_ZIP entities with selected=false by design, but the onClick handler immediately toggled them all to true before navigating to the next screen.

Simply invoke onSelectApk() directly, matching the behavior of the MD3 implementation which never had this issue. The back button's cleanup logic is preserved as-is, since it correctly clears any entities the user manually checked before going back to the initial choice.