### PR TITLE
fix: resolve negative resource IDs in ApkParser.resolveString and ApkParser.resolveDrawable

### DIFF
--- a/app/src/main/java/com/rosan/installer/data/engine/parser/ApkParser.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/parser/ApkParser.kt
@@ -191,15 +191,11 @@ object ApkParser : KoinComponent {
                 val versionCodeMinor = getAttributeIntValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionCode", 0).toLong()
                 versionCode = versionCodeMajor shl 32 or (versionCodeMinor and 0xffffffffL)
 
-                versionName = when (val resId = getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionName", -1)) {
-                    -1 -> getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionName") ?: versionName
-                    0 -> versionName
-                    else -> try {
-                        resources.getString(resId)
-                    } catch (_: Exception) {
-                        getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionName") ?: versionName
-                    }
-                }
+                versionName = resolveString(
+                    resources,
+                    getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionName", ResourcesCompat.ID_NULL),
+                    getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "versionName")
+                ) ?: versionName
             }
             .register("/manifest/uses-sdk") {
                 minSdk = getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "minSdkVersion")
@@ -208,19 +204,19 @@ object ApkParser : KoinComponent {
             .register("/manifest/application") {
                 label = resolveString(
                     resources,
-                    getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "label", -1),
+                    getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "label", ResourcesCompat.ID_NULL),
                     getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "label")
                 )
-                icon = resolveDrawable(resources, theme, getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "icon", -1))
+                icon = resolveDrawable(resources, theme, getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "icon", ResourcesCompat.ID_NULL))
                 roundIcon =
-                    resolveDrawable(resources, theme, getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "roundIcon", -1))
+                    resolveDrawable(resources, theme, getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "roundIcon", ResourcesCompat.ID_NULL))
             }
             .register("/manifest/application/meta-data") {
                 if (DeviceConfig.currentManufacturer == Manufacturer.OPPO || DeviceConfig.currentManufacturer == Manufacturer.ONEPLUS) {
                     if ("minOsdkVersion" == getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "name")) {
                         minOsdkVersion = resolveString(
                             resources,
-                            getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "value", -1),
+                            getAttributeResourceValue(AxmlTreeParser.ANDROID_NAMESPACE, "value", ResourcesCompat.ID_NULL),
                             getAttributeValue(AxmlTreeParser.ANDROID_NAMESPACE, "value")
                         )
                     }
@@ -284,23 +280,21 @@ object ApkParser : KoinComponent {
     }
 
     private fun resolveString(res: Resources, resId: Int, rawValue: String?): String? {
-        if (resId > 0) {
-            try {
-                return res.getString(resId)
-            } catch (_: Exception) {
-            }
+        if (resId == ResourcesCompat.ID_NULL) return rawValue
+        return try {
+            res.getString(resId)
+        } catch (_: Exception) {
+            rawValue
         }
-        return rawValue
     }
 
     private fun resolveDrawable(res: Resources, theme: Resources.Theme?, resId: Int): Drawable? {
-        if (resId > 0) {
-            try {
-                return ResourcesCompat.getDrawable(res, resId, theme)
-            } catch (_: Exception) {
-            }
+        if (resId == ResourcesCompat.ID_NULL) return null
+        return try {
+            ResourcesCompat.getDrawable(res, resId, theme)
+        } catch (_: Exception) {
+            null
         }
-        return null
     }
 
     private fun analyseAndSelectBestArchitecture(path: String, deviceSupportedArchs: List<Architecture>): Architecture? {


### PR DESCRIPTION
Change condition from resId > 0 to resId != -1 to properly handle resource IDs with package ID >= 0x80 which become negative integers in Java's signed 32-bit int representation.

## 背景

我的 LSPosed 模块需要向宿主注入资源，为了防止资源 ID 冲突，于是自定义自定义资源 ID 前缀为 0xAA

```kotlin
androidResources {
    // 用于添加模块资源到宿主。
    // 默认情况下，所有安卓应用的资源 ID 都是以 0x7f 开头
    // 为防止冲突，自定义资源 ID 前缀（--package-id），避开 0x7f 防止冲突
    additionalParameters += listOf(
        "--allow-reserved-package-id",
        "--package-id",
        "0xAA"
    )
}
```

## 现象

安装我的 LSPosed 模块时，应用名称显示为 `@-1442185207`

## 问题分析

Android 资源 ID 的格式是 0xPPTTEEEE

其中 0xPP 是 Package ID（包字节）。标准 Android 应用的资源 Package ID 是 0x7F = 127，对应的资源 ID（如 0x7F040001）作为 Java int 时是正数，条件 resId > 0 成立，能正常解析。

但我的 LSPosed 模块的 @string/app_name 对应的资源 ID 解析后得到的整数是 -1442185207，换算成十六进制是 0xAA0A0009。其中 Package ID 字节为 0xAA（0b10101010） = 170 > 127，当 Java 将其视为有符号 32 位整数时，结果是负数。

由于 `-1442185207 > 0` 为 `false` ，代码跳过了 `res.getString(resId)` 的调用，直接走到了 fallback：`return rawValue`

## 解决方案

将 `resolveString`（以及同文件的 `resolveDrawable`）中的 `if (resId > 0)` 改为 `if (resId != -1)`，因为 -1 才是 `getAttributeResourceValue` 约定的"无资源引用"哨兵值，而不是用正负来判断资源 ID 是否有效。

这里只是纯粹的资源读取，`getDrawable()` 或 `getString()` 能精确找到对应的资源，不会报错。这里不涉及Java 层的 View 系统，况且有 try catch 兜底，所以我认为这样改合理