### PR TITLE
feat: implement in-app language selection and Quick Settings tile

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,6 +188,7 @@ room {
 
 dependencies {
     compileOnly(project(":hidden-api"))
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.lifecycle)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,6 +154,17 @@
                 android:value="installer_processing" />
         </service>
 
+        <service
+            android:name=".ui.tile.SettingsTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_notification_logo"
+            android:label="@string/quick_settings_tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <provider
             android:name="rikka.shizuku.ShizukuProvider"
             android:authorities="${applicationId}.shizuku"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -173,6 +173,15 @@
             android:multiprocess="false"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
 
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/com/rosan/installer/SecretCodeReceiver.kt
+++ b/app/src/main/java/com/rosan/installer/SecretCodeReceiver.kt
@@ -22,15 +22,7 @@ class SecretCodeReceiver : BroadcastReceiver() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) intent.action == SECRET_CODE_ACTION
             else intent.action == SECRET_CODE_ACTION_OLD
         if (isSecretCodeAction) {
-            // The action is correct, proceed to launch the activity.
-            // Create an intent to launch the SettingsActivity.
-            val i = Intent(context, SettingsActivity::class.java).apply {
-                // Since we are starting an Activity from a non-Activity context,
-                // we must set the FLAG_ACTIVITY_NEW_TASK flag.
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            // Start the activity.
-            context.startActivity(i)
+            context.startActivity(SettingsActivity.createLaunchIntent(context))
         } else {
             // Log a warning if the action does not match.
             Timber.w("Received an intent with unexpected action: ${intent.action}")

--- a/app/src/main/java/com/rosan/installer/data/settings/provider/AppLanguageProviderImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/settings/provider/AppLanguageProviderImpl.kt
@@ -1,0 +1,74 @@
+package com.rosan.installer.data.settings.provider
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import com.rosan.installer.R
+import com.rosan.installer.domain.settings.model.AppLanguageOption
+import com.rosan.installer.domain.settings.provider.AppLanguageProvider
+import org.xmlpull.v1.XmlPullParser
+import java.util.Locale
+
+class AppLanguageProviderImpl(private val context: Context) : AppLanguageProvider {
+    private val cachedSupportedLanguages by lazy(LazyThreadSafetyMode.NONE) {
+        buildList {
+            add(
+                AppLanguageOption(
+                    languageTag = null,
+                    displayName = context.getString(R.string.app_language_follow_system)
+                )
+            )
+            addAll(loadLanguageTagsFromConfig().map(::toLanguageOption))
+        }
+    }
+
+    override fun getCurrentLanguageTag(): String? =
+        AppCompatDelegate.getApplicationLocales()
+            .toLanguageTags()
+            .substringBefore(',')
+            .ifBlank { null }
+
+    override fun getSupportedLanguages(): List<AppLanguageOption> = cachedSupportedLanguages
+
+    override fun setCurrentLanguageTag(languageTag: String?) {
+        val locales = if (languageTag.isNullOrBlank()) {
+            LocaleListCompat.getEmptyLocaleList()
+        } else {
+            LocaleListCompat.forLanguageTags(languageTag)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
+
+    private fun loadLanguageTagsFromConfig(): List<String> {
+        val parser = context.resources.getXml(R.xml.locales_config)
+        val languageTags = mutableListOf<String>()
+
+        try {
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                if (parser.eventType == XmlPullParser.START_TAG && parser.name == "locale") {
+                    parser.getAttributeValue(ANDROID_NS, "name")?.let(languageTags::add)
+                }
+            }
+        } finally {
+            parser.close()
+        }
+
+        return languageTags
+    }
+
+    private fun toLanguageOption(languageTag: String): AppLanguageOption {
+        val locale = Locale.forLanguageTag(languageTag)
+        val displayName = locale.getDisplayName(locale)
+
+        return AppLanguageOption(
+            languageTag = languageTag,
+            displayName = displayName.replaceFirstChar { firstChar ->
+                if (firstChar.isLowerCase()) firstChar.titlecase(locale) else firstChar.toString()
+            }
+        )
+    }
+
+    private companion object {
+        private const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+    }
+}

--- a/app/src/main/java/com/rosan/installer/di/SettingsModule.kt
+++ b/app/src/main/java/com/rosan/installer/di/SettingsModule.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.rosan.installer.data.settings.local.datastore.AppDataStore
 import com.rosan.installer.data.settings.local.room.InstallerRoom
+import com.rosan.installer.data.settings.provider.AppLanguageProviderImpl
 import com.rosan.installer.data.settings.provider.PrivilegedProviderImpl
 import com.rosan.installer.data.settings.provider.SystemAppProviderImpl
 import com.rosan.installer.data.settings.provider.SystemEnvProviderImpl
@@ -16,6 +17,7 @@ import com.rosan.installer.data.settings.repository.AppRepositoryImpl
 import com.rosan.installer.data.settings.repository.AppSettingsRepoImpl
 import com.rosan.installer.data.settings.repository.ConfigRepoImpl
 import com.rosan.installer.domain.settings.provider.PrivilegedProvider
+import com.rosan.installer.domain.settings.provider.AppLanguageProvider
 import com.rosan.installer.domain.settings.provider.SystemAppProvider
 import com.rosan.installer.domain.settings.provider.SystemEnvProvider
 import com.rosan.installer.domain.settings.provider.ThemeStateProvider
@@ -63,6 +65,7 @@ val settingsModule = module {
     singleOf(::AppSettingsRepoImpl) { bind<AppSettingsRepo>() }
 
     // Providers
+    singleOf(::AppLanguageProviderImpl) { bind<AppLanguageProvider>() }
     singleOf(::SystemEnvProviderImpl) { bind<SystemEnvProvider>() }
     singleOf(::SystemAppProviderImpl) { bind<SystemAppProvider>() }
     singleOf(::PrivilegedProviderImpl) { bind<PrivilegedProvider>() }

--- a/app/src/main/java/com/rosan/installer/domain/settings/model/AppLanguageOption.kt
+++ b/app/src/main/java/com/rosan/installer/domain/settings/model/AppLanguageOption.kt
@@ -1,0 +1,6 @@
+package com.rosan.installer.domain.settings.model
+
+data class AppLanguageOption(
+    val languageTag: String?,
+    val displayName: String
+)

--- a/app/src/main/java/com/rosan/installer/domain/settings/provider/AppLanguageProvider.kt
+++ b/app/src/main/java/com/rosan/installer/domain/settings/provider/AppLanguageProvider.kt
@@ -1,0 +1,9 @@
+package com.rosan.installer.domain.settings.provider
+
+import com.rosan.installer.domain.settings.model.AppLanguageOption
+
+interface AppLanguageProvider {
+    fun getCurrentLanguageTag(): String?
+    fun getSupportedLanguages(): List<AppLanguageOption>
+    fun setCurrentLanguageTag(languageTag: String?)
+}

--- a/app/src/main/java/com/rosan/installer/ui/activity/BiometricsAuthenticationActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/BiometricsAuthenticationActivity.kt
@@ -3,14 +3,14 @@
 package com.rosan.installer.ui.activity
 
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.FragmentActivity
 import com.rosan.installer.ui.common.auth.BiometricAuthBridge
 import timber.log.Timber
 
-class BiometricsAuthenticationActivity : FragmentActivity() {
+class BiometricsAuthenticationActivity : AppCompatActivity() {
     private var isResultSent = false
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
@@ -7,9 +7,9 @@ import android.content.pm.PackageInstaller
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
@@ -45,7 +45,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
 
-class InstallerActivity : ComponentActivity(), KoinComponent {
+class InstallerActivity : AppCompatActivity(), KoinComponent {
     companion object {
         const val KEY_ID = "installer_id"
         private const val ACTION_CONFIRM_INSTALL = "android.content.pm.action.CONFIRM_INSTALL"

--- a/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
@@ -7,9 +7,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
@@ -26,7 +26,7 @@ import org.koin.core.component.inject
 import androidx.compose.material3.Surface as Material3Surface
 import top.yukonga.miuix.kmp.basic.Surface as MiuixSurface
 
-class SettingsActivity : ComponentActivity(), KoinComponent {
+class SettingsActivity : AppCompatActivity(), KoinComponent {
     companion object {
         private const val LAUNCH_REQUEST_CODE = 1001
 

--- a/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
@@ -2,6 +2,9 @@
 // Copyright (C) 2025-2026 InstallerX Revived contributors
 package com.rosan.installer.ui.activity
 
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -24,6 +27,22 @@ import androidx.compose.material3.Surface as Material3Surface
 import top.yukonga.miuix.kmp.basic.Surface as MiuixSurface
 
 class SettingsActivity : ComponentActivity(), KoinComponent {
+    companion object {
+        private const val LAUNCH_REQUEST_CODE = 1001
+
+        fun createLaunchIntent(context: Context): Intent =
+            Intent(context, SettingsActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+
+        fun createLaunchPendingIntent(context: Context): PendingIntent = PendingIntent.getActivity(
+            context,
+            LAUNCH_REQUEST_CODE,
+            createLaunchIntent(context),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
     private val themeStateProvider by inject<ThemeStateProvider>()
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()

--- a/app/src/main/java/com/rosan/installer/ui/activity/UninstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/UninstallerActivity.kt
@@ -6,9 +6,9 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
@@ -37,7 +37,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
 
-class UninstallerActivity : ComponentActivity(), KoinComponent {
+class UninstallerActivity : AppCompatActivity(), KoinComponent {
     companion object {
         private const val KEY_ID = "uninstaller_id"
         private const val EXTRA_PACKAGE_NAME = "package_name"

--- a/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
+++ b/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
@@ -79,6 +79,7 @@ import androidx.compose.material.icons.twotone.SystemUpdate
 import androidx.compose.material.icons.twotone.TaskAlt
 import androidx.compose.material.icons.twotone.Terminal
 import androidx.compose.material.icons.twotone.Timer
+import androidx.compose.material.icons.twotone.Translate
 import androidx.compose.material.icons.twotone.Widgets
 
 /**
@@ -117,6 +118,7 @@ object AppIcons {
     val ViewSourceCode = Icons.TwoTone.Code
     val OpenSourceLicense = Icons.TwoTone.Copyright
     val Blur = Icons.TwoTone.BlurOn
+    val Translate = Icons.TwoTone.Translate
 
     // --- 导航图标集合 ---
     val RoomPreferences = Icons.TwoTone.RoomPreferences

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/AppLanguageDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/AppLanguageDialog.kt
@@ -1,0 +1,60 @@
+package com.rosan.installer.ui.page.main.settings.preferred.subpage.theme
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rosan.installer.R
+import com.rosan.installer.domain.settings.model.AppLanguageOption
+
+@Composable
+fun AppLanguageDialog(
+    currentLanguageTag: String?,
+    supportedLanguages: List<AppLanguageOption>,
+    onDismiss: () -> Unit,
+    onSelect: (String?) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.app_language)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                supportedLanguages.forEach { option ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(option.languageTag) }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = option.languageTag == currentLanguageTag,
+                            onClick = { onSelect(option.languageTag) }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(option.displayName)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.close))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
@@ -315,7 +315,7 @@ fun LegacyThemeSettingsPage(
                         SwitchWidget(
                             icon = AppIcons.BugReport,
                             title = stringResource(R.string.theme_settings_hide_launcher_icon),
-                            description = stringResource(R.string.theme_settings_hide_launcher_icon_desc),
+                            description = stringResource(R.string.theme_settings_hide_launcher_icon_desc_recovery),
                             checked = !uiState.showLauncherIcon,
                             isM3E = false,
                             onCheckedChange = { newCheckedState ->

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/LegacyThemeSettingsPage.kt
@@ -75,6 +75,10 @@ fun LegacyThemeSettingsPage(
 
     var showPaletteDialog by remember { mutableStateOf(false) }
     var showThemeModeDialog by remember { mutableStateOf(false) }
+    var showAppLanguageDialog by remember { mutableStateOf(false) }
+    val currentAppLanguage =
+        uiState.supportedAppLanguages.firstOrNull { it.languageTag == uiState.appLanguageTag }
+            ?: uiState.supportedAppLanguages.firstOrNull()
 
     if (showPaletteDialog) {
         PaletteStyleDialog(
@@ -94,6 +98,18 @@ fun LegacyThemeSettingsPage(
             onSelect = { mode ->
                 viewModel.dispatch(ThemeSettingsAction.SetThemeMode(mode))
                 showThemeModeDialog = false
+            }
+        )
+    }
+
+    if (showAppLanguageDialog) {
+        AppLanguageDialog(
+            currentLanguageTag = uiState.appLanguageTag,
+            supportedLanguages = uiState.supportedAppLanguages,
+            onDismiss = { showAppLanguageDialog = false },
+            onSelect = { languageTag ->
+                viewModel.dispatch(ThemeSettingsAction.SetAppLanguage(languageTag))
+                showAppLanguageDialog = false
             }
         )
     }
@@ -187,6 +203,14 @@ fun LegacyThemeSettingsPage(
                                 ThemeMode.SYSTEM -> stringResource(R.string.theme_settings_theme_mode_system)
                             },
                             onClick = { showThemeModeDialog = true }
+                        ) {}
+                    }
+                    item {
+                        BaseWidget(
+                            icon = AppIcons.Translate,
+                            title = stringResource(R.string.app_language),
+                            description = currentAppLanguage?.displayName,
+                            onClick = { showAppLanguageDialog = true }
                         ) {}
                     }
                     item {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
@@ -410,7 +410,7 @@ fun NewThemeSettingsPage(
                                 SwitchWidget(
                                     icon = AppIcons.Launcher,
                                     title = stringResource(R.string.theme_settings_hide_launcher_icon),
-                                    description = stringResource(R.string.theme_settings_hide_launcher_icon_desc),
+                                    description = stringResource(R.string.theme_settings_hide_launcher_icon_desc_recovery),
                                     checked = !uiState.showLauncherIcon,
                                     onCheckedChange = { newCheckedState ->
                                         if (newCheckedState) {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/NewThemeSettingsPage.kt
@@ -99,7 +99,11 @@ fun NewThemeSettingsPage(
     var showHideLauncherIconDialog by remember { mutableStateOf(false) }
     var showPaletteDialog by remember { mutableStateOf(false) }
     var showThemeModeDialog by remember { mutableStateOf(false) }
+    var showAppLanguageDialog by remember { mutableStateOf(false) }
     var showBlurWarningDialog by remember { mutableStateOf(false) }
+    val currentAppLanguage =
+        uiState.supportedAppLanguages.firstOrNull { it.languageTag == uiState.appLanguageTag }
+            ?: uiState.supportedAppLanguages.firstOrNull()
 
     if (showPaletteDialog) {
         PaletteStyleDialog(
@@ -119,6 +123,18 @@ fun NewThemeSettingsPage(
             onSelect = { mode ->
                 viewModel.dispatch(ThemeSettingsAction.SetThemeMode(mode))
                 showThemeModeDialog = false
+            }
+        )
+    }
+
+    if (showAppLanguageDialog) {
+        AppLanguageDialog(
+            currentLanguageTag = uiState.appLanguageTag,
+            supportedLanguages = uiState.supportedAppLanguages,
+            onDismiss = { showAppLanguageDialog = false },
+            onSelect = { languageTag ->
+                viewModel.dispatch(ThemeSettingsAction.SetAppLanguage(languageTag))
+                showAppLanguageDialog = false
             }
         )
     }
@@ -272,6 +288,14 @@ fun NewThemeSettingsPage(
                                         ThemeMode.SYSTEM -> stringResource(R.string.theme_settings_theme_mode_system)
                                     },
                                     onClick = { showThemeModeDialog = true }
+                                ) {}
+                            }
+                            item {
+                                BaseWidget(
+                                    icon = AppIcons.Translate,
+                                    title = stringResource(R.string.app_language),
+                                    description = currentAppLanguage?.displayName,
+                                    onClick = { showAppLanguageDialog = true }
                                 ) {}
                             }
                             item {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsAction.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsAction.kt
@@ -19,6 +19,7 @@ sealed class ThemeSettingsAction {
     data class SetDynColorFollowPkgIcon(val follow: Boolean) : ThemeSettingsAction()
     data class SetDynColorFollowPkgIconForLiveActivity(val follow: Boolean) : ThemeSettingsAction()
     data class SetSeedColor(val color: Color) : ThemeSettingsAction()
+    data class SetAppLanguage(val languageTag: String?) : ThemeSettingsAction()
     data class ChangePreferSystemIcon(val preferSystemIcon: Boolean) : ThemeSettingsAction()
     data class ChangeShowLauncherIcon(val showLauncherIcon: Boolean) : ThemeSettingsAction()
 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsState.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsState.kt
@@ -3,6 +3,7 @@
 package com.rosan.installer.ui.page.main.settings.preferred.subpage.theme
 
 import androidx.compose.ui.graphics.Color
+import com.rosan.installer.domain.settings.model.AppLanguageOption
 import com.rosan.installer.ui.theme.material.PaletteStyle
 import com.rosan.installer.ui.theme.material.PresetColors
 import com.rosan.installer.ui.theme.material.RawColor
@@ -21,6 +22,8 @@ data class ThemeSettingsState(
     val useMiuixMonet: Boolean = false,
     val seedColor: Color = PresetColors[0].color,
     val availableColors: List<RawColor> = PresetColors,
+    val appLanguageTag: String? = null,
+    val supportedAppLanguages: List<AppLanguageOption> = emptyList(),
     val useDynColorFollowPkgIcon: Boolean = false,
     val useDynColorFollowPkgIconForLiveActivity: Boolean = false,
     val preferSystemIcon: Boolean = false,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/subpage/theme/ThemeSettingsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rosan.installer.domain.settings.provider.AppLanguageProvider
 import com.rosan.installer.domain.settings.provider.SystemEnvProvider
 import com.rosan.installer.domain.settings.repository.AppSettingsRepo
 import com.rosan.installer.domain.settings.repository.BooleanSetting
@@ -19,20 +20,25 @@ import com.rosan.installer.ui.theme.material.RawColor
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class ThemeSettingsViewModel(
     appSettingsRepo: AppSettingsRepo,
+    private val appLanguageProvider: AppLanguageProvider,
     systemEnvProvider: SystemEnvProvider,
     private val updateSetting: UpdateSettingUseCase,
     private val setLauncherIconUseCase: SetLauncherIconUseCase
 ) : ViewModel() {
+    private val appLanguageTag = MutableStateFlow(appLanguageProvider.getCurrentLanguageTag())
+    private val supportedAppLanguages = appLanguageProvider.getSupportedLanguages()
 
     val state: StateFlow<ThemeSettingsState> = combine(
         appSettingsRepo.preferencesFlow,
-        systemEnvProvider.getWallpaperColorsFlow()
-    ) { prefs, wallpaperColors ->
+        systemEnvProvider.getWallpaperColorsFlow(),
+        appLanguageTag
+    ) { prefs, wallpaperColors, currentLanguageTag ->
         val manualSeedColor = Color(prefs.seedColorInt)
         val effectiveSeedColor: Color = if (prefs.useDynamicColor && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             if (!wallpaperColors.isNullOrEmpty()) {
@@ -64,6 +70,8 @@ class ThemeSettingsViewModel(
             useMiuixMonet = prefs.useMiuixMonet,
             seedColor = effectiveSeedColor,
             availableColors = availableColors,
+            appLanguageTag = currentLanguageTag,
+            supportedAppLanguages = supportedAppLanguages,
             useDynColorFollowPkgIcon = prefs.useDynColorFollowPkgIcon,
             useDynColorFollowPkgIconForLiveActivity = prefs.useDynColorFollowPkgIconForLiveActivity,
             preferSystemIcon = prefs.preferSystemIcon,
@@ -108,6 +116,10 @@ class ThemeSettingsViewModel(
             }
 
             is ThemeSettingsAction.SetSeedColor -> viewModelScope.launch { updateSetting(IntSetting.ThemeSeedColor, action.color.toArgb()) }
+            is ThemeSettingsAction.SetAppLanguage -> {
+                appLanguageProvider.setCurrentLanguageTag(action.languageTag)
+                appLanguageTag.value = appLanguageProvider.getCurrentLanguageTag()
+            }
             is ThemeSettingsAction.ChangePreferSystemIcon -> viewModelScope.launch {
                 updateSetting(
                     BooleanSetting.PreferSystemIconForInstall,

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
@@ -215,6 +215,7 @@ fun HideLauncherIconWarningDialog(
             title = { Text(text = dialogTitle) },
             text = {
                 Column {
+                    Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning_recovery))
                     Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning))
                     if (DeviceConfig.currentManufacturer == Manufacturer.XIAOMI)
                         Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning_xiaomi))

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
@@ -44,6 +44,7 @@ import com.rosan.installer.ui.page.main.settings.preferred.subpage.theme.ThemeSe
 import com.rosan.installer.ui.page.main.widget.card.ColorSwatchPreview
 import com.rosan.installer.ui.page.miuix.widgets.MiuixBackButton
 import com.rosan.installer.ui.page.miuix.widgets.MiuixBlurWarningDialog
+import com.rosan.installer.ui.page.miuix.widgets.MiuixAppLanguageWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixColorSpecWidget
 import com.rosan.installer.ui.page.miuix.widgets.MiuixHideLauncherIconWarningDialog
 import com.rosan.installer.ui.page.miuix.widgets.MiuixPaletteStyleWidget
@@ -159,6 +160,17 @@ fun MiuixThemeSettingsPage(
                                 currentThemeMode = uiState.themeMode,
                                 onThemeModeChange = { newMode ->
                                     viewModel.dispatch(ThemeSettingsAction.SetThemeMode(newMode))
+                                }
+                            )
+                            MiuixAppLanguageWidget(
+                                currentLanguageTag = uiState.appLanguageTag,
+                                supportedLanguages = uiState.supportedAppLanguages,
+                                onLanguageChange = { languageTag ->
+                                    viewModel.dispatch(
+                                        ThemeSettingsAction.SetAppLanguage(
+                                            languageTag
+                                        )
+                                    )
                                 }
                             )
                             MiuixSwitchWidget(

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/subpage/theme/MiuixThemeSettingsPage.kt
@@ -343,7 +343,7 @@ fun MiuixThemeSettingsPage(
                         ) {
                             MiuixSwitchWidget(
                                 title = stringResource(R.string.theme_settings_hide_launcher_icon),
-                                description = stringResource(R.string.theme_settings_hide_launcher_icon_desc),
+                                description = stringResource(R.string.theme_settings_hide_launcher_icon_desc_recovery),
                                 checked = !uiState.showLauncherIcon,
                                 onCheckedChange = { newCheckedState ->
                                     if (newCheckedState) {

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixDialog.kt
@@ -132,6 +132,7 @@ fun MiuixHideLauncherIconWarningDialog(
             // Custom content layout with body text and action buttons
             Column {
                 // Warning message
+                Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning_recovery))
                 Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning))
                 if (DeviceConfig.currentManufacturer == Manufacturer.XIAOMI)
                     Text(stringResource(R.string.theme_settings_hide_launcher_icon_warning_xiaomi))

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixSettingsItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/widgets/MiuixSettingsItemWidget.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rosan.installer.R
 import com.rosan.installer.data.engine.executor.PackageManagerUtil
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
+import com.rosan.installer.domain.settings.model.AppLanguageOption
 import com.rosan.installer.domain.settings.model.Authorizer
 import com.rosan.installer.domain.settings.model.InstallMode
 import com.rosan.installer.domain.settings.model.NamedPackage
@@ -610,6 +611,41 @@ fun MiuixThemeModeWidget(
             // Invoke the callback only if the mode has actually changed.
             if (currentThemeMode != newMode) {
                 onThemeModeChange(newMode)
+            }
+        }
+    )
+}
+
+@Composable
+fun MiuixAppLanguageWidget(
+    modifier: Modifier = Modifier,
+    currentLanguageTag: String?,
+    supportedLanguages: List<AppLanguageOption>,
+    onLanguageChange: (String?) -> Unit
+) {
+    val spinnerEntries = remember(supportedLanguages) {
+        supportedLanguages.map { SpinnerEntry(title = it.displayName) }
+    }
+    val selectedIndex = remember(currentLanguageTag, supportedLanguages) {
+        supportedLanguages.indexOfFirst { it.languageTag == currentLanguageTag }
+            .takeIf { it >= 0 }
+            ?: 0
+    }
+
+    SuperSpinner(
+        modifier = modifier,
+        title = stringResource(id = R.string.app_language),
+        items = spinnerEntries,
+        selectedIndex = selectedIndex,
+        onSelectedIndexChange = { newIndex ->
+            supportedLanguages.getOrNull(newIndex)?.languageTag?.let { selectedTag ->
+                if (currentLanguageTag != selectedTag) {
+                    onLanguageChange(selectedTag)
+                }
+            } ?: run {
+                if (currentLanguageTag != null) {
+                    onLanguageChange(null)
+                }
             }
         }
     )

--- a/app/src/main/java/com/rosan/installer/ui/tile/SettingsTileService.kt
+++ b/app/src/main/java/com/rosan/installer/ui/tile/SettingsTileService.kt
@@ -1,0 +1,35 @@
+package com.rosan.installer.ui.tile
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import com.rosan.installer.R
+import com.rosan.installer.ui.activity.SettingsActivity
+
+class SettingsTileService : TileService() {
+    override fun onStartListening() {
+        super.onStartListening()
+        qsTile?.apply {
+            label = getString(R.string.quick_settings_tile_label)
+            state = Tile.STATE_ACTIVE
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                subtitle = getString(R.string.quick_settings_tile_subtitle)
+            }
+            updateTile()
+        }
+    }
+
+    override fun onClick() {
+        super.onClick()
+        unlockAndRun(::openSettings)
+    }
+
+    private fun openSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startActivityAndCollapse(SettingsActivity.createLaunchPendingIntent(this))
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(SettingsActivity.createLaunchIntent(this))
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -457,4 +457,8 @@
     <string name="pull_to_refresh_hint2">الإصدار للتحديث</string>
     <string name="pull_to_refresh_hint3">جارٍ الإنعاش…</string>
     <string name="pull_to_refresh_hint4">تم تحديثه بنجاح</string>
+    <string name="app_language">لغة التطبيق</string>
+    <string name="app_language_follow_system">اتباع لغة النظام</string>
 </resources>
+
+

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -658,4 +658,8 @@
     <string name="installer_author">Autor: %1$s</string>
     <string name="lab_module_always_use_root">Immer root nutzen, um Module zu flashen</string>
     <string name="lab_module_always_use_root_desc">Wenn installerX als System-installer ausgeführt wird, immer root nutzen um Module zu flashen, um beste Performance zu erzielen</string>
+    <string name="app_language">App-Sprache</string>
+    <string name="app_language_follow_system">Systemsprache verwenden</string>
 </resources>
+
+

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -707,4 +707,8 @@
     <string name="lab_mi_island_desc">Estilo de notificación global. La verificación de firma del sistema solo puede ser evitada cuando el autenticador de aplicación personalizado está configurado en Shizuku. Los usuarios de root pueden habilitar esto directamente tras desactivar manualmente las restricciones de firma</string>
     <string name="config_label_preferences">Preferencias</string>
     <string name="exception_install_parse_failed_bad_shared_user_id">Las aplicaciones no preinstaladas tienen prohibido usar el UID compartido del sistema</string>
+    <string name="app_language">Idioma de la aplicación</string>
+    <string name="app_language_follow_system">Seguir idioma del sistema</string>
 </resources>
+
+

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -315,4 +315,8 @@
     <string name="installer_analyse_failed">تحلیل ناموفق بود</string>
     <string name="installer_select_install">انتخاب برنامه‌ها برای نصب</string>
     <string name="installer_select_split">انتخاب بخش‌های APK</string>
+    <string name="app_language">زبان برنامه</string>
+    <string name="app_language_follow_system">پیروی از زبان سیستم</string>
 </resources>
+
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -578,4 +578,6 @@
     <string name="config_install_mode_desc">Mode d\'installation par défaut et paramètres associés</string>
     <string name="config_install_reason">Raison de l\'installation</string>
     <string name="config_install_reason_unknown">Inconnu</string>
+    <string name="app_language">Langue de l\'application</string>
+    <string name="app_language_follow_system">Suivre la langue du système</string>
 </resources>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -43,4 +43,8 @@
     <string name="theme_settings_google_ui">ગૂગલ મટિરિયલ ૩</string>
     <string name="theme_settings_use_expressive_ui">એક્સ્પ્રેસીવ યુઆઈ વાપરો</string>
     <string name="theme_settings_use_blur">ઝાંખું ચાલુ કરો</string>
+    <string name="app_language">એપ ભાષા</string>
+    <string name="app_language_follow_system">સિસ્ટમ ભાષા અનુસરો</string>
 </resources>
+
+

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -650,4 +650,8 @@
     <string name="lab_unstable_features">Instabil funkciók</string>
     <string name="lab_set_install_requester">Telepítési kérelmező beállítása</string>
     <string name="lab_set_install_requester_desc">Töltsd ki az OriganitingUid mezőt a hívó csomaggal, hogy az illeszkedjen a rendszer viselkedéséhez</string>
+    <string name="app_language">Alkalmazás nyelve</string>
+    <string name="app_language_follow_system">Rendszernyelv követése</string>
 </resources>
+
+

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -693,4 +693,8 @@
     <string name="config_apk_choose_all">Secara bawaan, semua APK akan dipilih selama instalasi massal</string>
     <string name="config_apk_choose_all_desc">Secara bawaan, semua berkas APK akan dipilih untuk sesi dengan banyak file.</string>
     <string name="lab_mi_island_desc">Gaya notifikasi global. Verifikasi tanda tangan sistem hanya dapat dilewati jika app-authenticator kustom diatur ke Shizuku. Pengguna root dapat mengaktifkannya langsung setelah menonaktifkan pembatasan tanda tangan secara manual</string>
+    <string name="app_language">Bahasa aplikasi</string>
+    <string name="app_language_follow_system">Ikuti bahasa sistem</string>
 </resources>
+
+

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -55,4 +55,6 @@
     <string name="theme_settings_miuix_custom_colors">Colori personalizzati</string>
     <string name="theme_settings_miuix_custom_colors_desc">Personalizza i colori del tema in stile Miuix</string>
     <string name="theme_settings_google_ui">Google Material 3</string>
+    <string name="app_language">Lingua dell\'app</string>
+    <string name="app_language_follow_system">Segui la lingua di sistema</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -690,4 +690,8 @@
     <string name="split_name_language">言語分割: %1$s</string>
     <string name="split_name_architecture">アーキテクチャー分割: %1$s</string>
     <string name="split_name_density">ピクセル密度: %1$s</string>
+    <string name="app_language">アプリの言語</string>
+    <string name="app_language_follow_system">システムの言語に従う</string>
 </resources>
+
+

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -151,4 +151,8 @@
     <string name="save_logs_desc">디버깅을 위해 로그를 로컬 파일에 저장합니다</string>
     <string name="export_logs">수출 로그</string>
     <string name="export_logs_desc">앱의 로그 내보내기</string>
+    <string name="app_language">앱 언어</string>
+    <string name="app_language_follow_system">시스템 언어 따르기</string>
 </resources>
+
+

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -76,4 +76,8 @@
     <string name="uninstall_keep_data_desc">Nedzēst, bet paturēt lietotnes datus un kešatmiņu</string>
     <string name="uninstall_all_users">Visiem lietotājiem</string>
     <string name="uninstall_all_users_desc">Noņem šo lietotni visiem šīs ierīces lietotājiem</string>
+    <string name="app_language">Lietotnes valoda</string>
+    <string name="app_language_follow_system">Sekot sistēmas valodai</string>
 </resources>
+
+

--- a/app/src/main/res/values-night-v29/themes.xml
+++ b/app/src/main/res/values-night-v29/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
     </style>
 

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:windowSplashScreenBackground">@android:color/background_dark</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar" />
 
     <style name="Theme.Installer.Translucent.AppCompat" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -697,4 +697,8 @@
     <string name="config_apk_choose_all">Selecteer standaard alle APK\'s tijdens het meerdere installeren</string>
     <string name="config_apk_choose_all_desc">Selecteer standaard alle APK\'s voor meerdere bestandssessies.</string>
     <string name="exception_install_parse_failed_bad_shared_user_id">Niet vooraf geïnstalleerde apps kunnen niet de gedeelde UID van het systeem gebruiken</string>
+    <string name="app_language">App-taal</string>
+    <string name="app_language_follow_system">Systeemtaal volgen</string>
 </resources>
+
+

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -90,4 +90,8 @@
     <string name="theme_settings_use_live_activity_desc">Użyj Aktywności na żywo zamiast powiadomień. Może nie być obsługiwane na niestandardowych ROM-ach</string>
     <string name="theme_settings_package_icons">Źródło ikony pakietu</string>
     <string name="theme_settings_prefer_system_icon">Użyj ikony systemowej dla instalacji aplikacji</string>
+    <string name="app_language">Język aplikacji</string>
+    <string name="app_language_follow_system">Użyj języka systemowego</string>
 </resources>
+
+

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -697,4 +697,6 @@
     <string name="lab_mi_island">Mi Super Island</string>
     <string name="lab_mi_island_desc">Estilo de notificação global. A verificação da assinatura do sistema só pode ser ignorada quando o autenticador de aplicativos personalizado estiver definido como Shizuku. Os usuários root podem ativar isso diretamente após desativar manualmente as restrições de assinatura</string>
     <string name="exception_install_parse_failed_bad_shared_user_id">Apps não pré-carregados são proibidos de usar o UID compartilhado do sistema</string>
+    <string name="app_language">Idioma do app</string>
+    <string name="app_language_follow_system">Seguir idioma do sistema</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -695,4 +695,8 @@
     <string name="exception_resolve_failed_link_not_valid">Эта ссылка не содержит действительный файл</string>
     <string name="tag_arch_emulated">Разрядность</string>
     <string name="exception_install_parse_failed_bad_shared_user_id">Сторонним приложениям запрещено использовать системный ID</string>
+    <string name="app_language">Язык приложения</string>
+    <string name="app_language_follow_system">Использовать язык системы</string>
 </resources>
+
+

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -369,4 +369,8 @@
     <string name="virtual_preload_desc">ระบุว่าแพ็คเกจเป็น Virtual Preload</string>
     <string name="install_anyway">ติดตั้งต่อไป</string>
     <string name="reinstall">ติดตั้งใหม่</string>
+    <string name="app_language">ภาษาของแอป</string>
+    <string name="app_language_follow_system">ใช้ภาษาของระบบ</string>
 </resources>
+
+

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -697,4 +697,8 @@
     <string name="config_apk_choose_all">Toplu yükleme sırasında varsayılan olarak tüm APK\'ları seçin</string>
     <string name="config_apk_choose_all_desc">Çoklu dosya oturumlarında varsayılan olarak tüm APK\'lar seçilir.</string>
     <string name="exception_install_parse_failed_bad_shared_user_id">Sistem tarafından önceden yüklenmiş olmayan uygulamaların shared UID\'yi kullanımı yasaktır</string>
+    <string name="app_language">Uygulama dili</string>
+    <string name="app_language_follow_system">Sistem dilini takip et</string>
 </resources>
+
+

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -460,4 +460,8 @@
     <string name="uninstall_call_uninstaller_manually_desc">Видалити програму за вказаною назвою пакета</string>
     <string name="uninstall_progress_text">Видалення...</string>
     <string name="uninstall_enter_package_name">Введіть назву пакета, щоб видалити</string>
+    <string name="app_language">Мова застосунку</string>
+    <string name="app_language_follow_system">Використовувати мову системи</string>
 </resources>
+
+

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.DeviceDefault.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!--    Compat Navigation Bar Color when ModalBottomSheet activated    -->
         <item name="android:enforceNavigationBarContrast">false</item>
     </style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowSplashScreenBackground">@android:color/background_light</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
     </style>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="agreement_title">Chính sách</string>
+    <string name="app_language">Ngôn ngữ ứng dụng</string>
+    <string name="app_language_follow_system">Theo ngôn ngữ hệ thống</string>
 </resources>
+
+

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -719,4 +719,8 @@
     <string name="lab_mi_island_desc">覆盖全局通知样式。仅当应用授权器设置为 Shizuku 时可绕过系统签名限制；Root 用户在手动关闭系统签名验证后可直接开启</string>
     <string name="lab_tap_icon_to_share">点击图标分享安装包</string>
     <string name="lab_tap_icon_to_share_desc">在安装准备界面点击应用图标即可分享安装包</string>
+    <string name="app_language">应用语言</string>
+    <string name="app_language_follow_system">跟随系统语言</string>
 </resources>
+
+

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -106,8 +106,12 @@
     <string name="theme_settings_launcher_icons">桌面图标</string>
     <string name="theme_settings_hide_launcher_icon">隐藏桌面图标</string>
     <string name="theme_settings_hide_launcher_icon_desc">通过 *#*#46789#*#* 来访问设置</string>
+    <string name="theme_settings_hide_launcher_icon_desc_recovery">添加快捷设置磁贴，或通过 *#*#46789#*#* 来访问设置</string>
+    <string name="theme_settings_hide_launcher_icon_warning_recovery">如果你希望隐藏桌面图标后还能从状态栏打开，请先把 InstallerX 磁贴加到快捷设置里。</string>
     <string name="theme_settings_hide_launcher_icon_warning">请在隐藏之前确认你能够访问本应用设置界面！</string>
     <string name="theme_settings_hide_launcher_icon_warning_xiaomi">对于 HyperOS，请允许“自启动”和“后台弹出界面”，以接收拨号界面代码！</string>
+    <string name="quick_settings_tile_label">InstallerX</string>
+    <string name="quick_settings_tile_subtitle">打开设置</string>
     <string name="installer_settings">安装器设置</string>
     <string name="installer_settings_desc">更改安装器的全局设置</string>
     <string name="uninstaller_settings">卸载器设置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -711,4 +711,8 @@
     <string name="lab_mi_island">小米超級島</string>
     <string name="lab_mi_island_desc">覆蓋全域通知樣式。 僅當應用授權器設定為 Shizuku 時可繞過系統簽名限制；Root 使用者在手動關閉系統簽名驗證後可直接開啟</string>
     <string name="app_version_info_format">%1$s %2$s %3$s (%4$s)</string>
+    <string name="app_language">應用程式語言</string>
+    <string name="app_language_follow_system">跟隨系統語言</string>
 </resources>
+
+

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -82,8 +82,12 @@
     <string name="theme_settings_launcher_icons">桌面圖示</string>
     <string name="theme_settings_hide_launcher_icon">隱藏桌面圖示</string>
     <string name="theme_settings_hide_launcher_icon_desc">透過 *#*#46789#*#* 來存取設定</string>
+    <string name="theme_settings_hide_launcher_icon_desc_recovery">加入快捷設定磁貼，或透過 *#*#46789#*#* 來存取設定</string>
+    <string name="theme_settings_hide_launcher_icon_warning_recovery">如果您希望隱藏桌面圖示後仍能從狀態列開啟，請先把 InstallerX 磁貼加入快捷設定。</string>
     <string name="theme_settings_hide_launcher_icon_warning">請在隱藏之前確認您能夠存取本應用程式設定介面！</string>
     <string name="theme_settings_hide_launcher_icon_warning_xiaomi">對於 HyperOS，請允許「自啟動」和「背景彈出介面」，以接收撥號介面代碼！</string>
+    <string name="quick_settings_tile_label">InstallerX</string>
+    <string name="quick_settings_tile_subtitle">開啟設定</string>
     <string name="installer_settings">安裝程式設定</string>
     <string name="installer_settings_desc">更改安裝程式的全域設定</string>
     <string name="installer_settings_global_installer">全域</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -736,4 +736,8 @@
     <string name="lab_mi_island_desc">Global notification style. System signature verification can only be bypassed when the custom app-authenticator is set to Shizuku. Root users can enable this directly after manually disabling signature restrictions</string>
     <string name="lab_tap_icon_to_share">Tap icon to share apk</string>
     <string name="lab_tap_icon_to_share_desc">Tap icon on the prepare page to share apk</string>
+    <string name="app_language">App language</string>
+    <string name="app_language_follow_system">Follow system language</string>
 </resources>
+
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,8 +110,12 @@
     <string name="theme_settings_launcher_icons">Launcher icon</string>
     <string name="theme_settings_hide_launcher_icon">Hide launcher icon</string>
     <string name="theme_settings_hide_launcher_icon_desc">Dial *#*#46789#*#* to open settings</string>
+    <string name="theme_settings_hide_launcher_icon_desc_recovery">Add the Quick Settings tile, or dial *#*#46789#*#* to open settings</string>
+    <string name="theme_settings_hide_launcher_icon_warning_recovery">Add the InstallerX Quick Settings tile first if you want to reopen it from the status bar after hiding the launcher icon.</string>
     <string name="theme_settings_hide_launcher_icon_warning">Please make sure you can access this page before hiding launcher icon!</string>
     <string name="theme_settings_hide_launcher_icon_warning_xiaomi">For HyperOS, please allow "Autostart" and "Open new windows while running in the background" to receive dialer code!</string>
+    <string name="quick_settings_tile_label">InstallerX</string>
+    <string name="quick_settings_tile_subtitle">Open settings</string>
     <string name="installer_settings">Installer Settings</string>
     <string name="installer_settings_desc">Change the global settings of the installer</string>
     <string name="uninstaller_settings">Uninstaller Settings</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Installer" parent="Theme.AppCompat.DayNight.NoActionBar" />
 
     <style name="Theme.Installer.Translucent" parent="Theme.Installer">
         <item name="android:windowIsTranslucent">true</item>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -4,11 +4,17 @@
     <locale android:name="ar" />
     <locale android:name="de" />
     <locale android:name="es" />
+    <locale android:name="fa" />
     <locale android:name="fr" />
+    <locale android:name="gu" />
     <locale android:name="hu" />
     <locale android:name="id" />
+    <locale android:name="it" />
     <locale android:name="ja" />
+    <locale android:name="ko" />
+    <locale android:name="lv" />
     <locale android:name="nl" />
+    <locale android:name="pl" />
     <locale android:name="pt-BR" />
     <locale android:name="ru" />
     <locale android:name="th" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@
 
 [versions]
 agp = "9.1.0"
+appcompat = "1.7.1"
 biometric = "1.4.0-alpha05"
 capsule = "2.1.3"
 focusApi = "1.4"
@@ -42,6 +43,7 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 
 [libraries]
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.18.0" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
- add `SettingsTileService` to provide a Quick Settings tile for opening app settings
- register the tile service in `AndroidManifest.xml` with the required permission and intent filter
- use `PendingIntent` with `startActivityAndCollapse` on Android 14+ for tile launches
- centralize settings launch intent creation in `SettingsActivity`
- reuse the centralized settings launch logic in `SecretCodeReceiver`
- update hide-launcher-icon descriptions and warning dialogs across Standard, New, and Miuix UIs
- add Quick Settings tile strings and recovery copy in English, Simplified Chinese, and Traditional Chinese