### PR TITLE
Add in-app language picker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ room3 {
 dependencies {
     compileOnly(project(":hidden-api"))
     implementation(libs.androidx.core)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.lifecycle)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -160,6 +160,15 @@
         </service>
 
         <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
+
+        <service
             android:label="@string/app_name"
             android:icon="@drawable/ic_tile_icon"
             android:name="com.rosan.installer.framework.tile.SettingsTileService"

--- a/app/src/main/java/com/rosan/installer/ui/activity/BiometricsAuthenticationActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/BiometricsAuthenticationActivity.kt
@@ -3,14 +3,14 @@
 package com.rosan.installer.ui.activity
 
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.FragmentActivity
 import com.rosan.installer.ui.common.auth.BiometricAuthBridge
 import timber.log.Timber
 
-class BiometricsAuthenticationActivity : FragmentActivity() {
+class BiometricsAuthenticationActivity : AppCompatActivity() {
     private var isResultSent = false
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/InstallerActivity.kt
@@ -9,9 +9,9 @@ import android.content.pm.PackageInstaller
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
@@ -48,7 +48,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
 
-class InstallerActivity : ComponentActivity(), KoinComponent {
+class InstallerActivity : AppCompatActivity(), KoinComponent {
     companion object {
         const val KEY_ID = "installer_id"
         private const val ACTION_CONFIRM_INSTALL = "android.content.pm.action.CONFIRM_INSTALL"

--- a/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/SettingsActivity.kt
@@ -4,9 +4,9 @@ package com.rosan.installer.ui.activity
 
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,7 +26,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
-class SettingsActivity : ComponentActivity(), KoinComponent {
+class SettingsActivity : AppCompatActivity(), KoinComponent {
     private val themeStateProvider by inject<ThemeStateProvider>()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/rosan/installer/ui/activity/UninstallerActivity.kt
+++ b/app/src/main/java/com/rosan/installer/ui/activity/UninstallerActivity.kt
@@ -8,9 +8,9 @@ import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
@@ -40,7 +40,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
 
-class UninstallerActivity : ComponentActivity(), KoinComponent {
+class UninstallerActivity : AppCompatActivity(), KoinComponent {
     companion object {
         private const val KEY_ID = "uninstaller_id"
         private const val EXTRA_PACKAGE_NAME = "package_name"

--- a/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
+++ b/app/src/main/java/com/rosan/installer/ui/icons/AppIcons.kt
@@ -61,6 +61,7 @@ import androidx.compose.material.icons.twotone.HourglassDisabled
 import androidx.compose.material.icons.twotone.HourglassEmpty
 import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.KeyboardArrowDown
+import androidx.compose.material.icons.twotone.Language
 import androidx.compose.material.icons.twotone.LibraryAddCheck
 import androidx.compose.material.icons.twotone.LocalPolice
 import androidx.compose.material.icons.twotone.Memory
@@ -124,6 +125,7 @@ object AppIcons {
     val ViewSourceCode = Icons.TwoTone.Code
     val OpenSourceLicense = Icons.TwoTone.Copyright
     val Blur = Icons.TwoTone.BlurOn
+    val Language = Icons.TwoTone.Language
 
     // --- 导航图标集合 ---
     val RoomPreferences = Icons.TwoTone.RoomPreferences

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/NewPreferredPage.kt
@@ -195,6 +195,7 @@ fun NewPreferredPage(
                             }
                         )
                     }
+                    item { AppLanguageWidget() }
                 }
             }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredItemWidget.kt
@@ -88,6 +88,7 @@ import com.rosan.installer.ui.page.main.widget.setting.DropDownMenuWidget
 import com.rosan.installer.ui.page.main.widget.setting.SwitchWidget
 import com.rosan.installer.ui.theme.material.PaletteStyle
 import com.rosan.installer.ui.theme.material.ThemeColorSpec
+import com.rosan.installer.util.AppLanguageManager
 import com.rosan.installer.util.hasFlag
 import org.koin.compose.koinInject
 
@@ -435,6 +436,30 @@ fun SettingsNavigationItemWidget(
             contentDescription = null
         )
     }
+}
+
+@Composable
+fun AppLanguageWidget() {
+    val context = LocalContext.current
+    var selectedLanguageTag by remember { mutableStateOf(AppLanguageManager.getSelectedLanguageTag()) }
+    val languageTags = AppLanguageManager.supportedLanguageTags
+    val labels = languageTags.map { AppLanguageManager.displayName(context, it) }
+    val selectedIndex = languageTags.indexOf(selectedLanguageTag).coerceAtLeast(0)
+
+    DropDownMenuWidget(
+        icon = AppIcons.Language,
+        title = stringResource(R.string.app_language),
+        description = labels[selectedIndex],
+        choice = selectedIndex,
+        data = labels,
+        onChoiceChange = { index ->
+            val languageTag = languageTags[index]
+            if (selectedLanguageTag != languageTag) {
+                AppLanguageManager.setSelectedLanguageTag(languageTag)
+                selectedLanguageTag = languageTag
+            }
+        }
+    )
 }
 
 /**

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
@@ -179,6 +179,7 @@ fun PreferredPage(
                     }
                 )
             }
+            item { AppLanguageWidget() }
             if (uiState.authorizer == Authorizer.None)
                 item {
                     val tip = if (capabilityProvider.isSystemApp) stringResource(R.string.config_authorizer_none_system_app_tips)

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredItemWidget.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredItemWidget.kt
@@ -56,6 +56,7 @@ import com.rosan.installer.ui.page.miuix.widgets.MiuixSwitchWidget
 import com.rosan.installer.ui.theme.material.PaletteStyle
 import com.rosan.installer.ui.theme.material.ThemeColorSpec
 import com.rosan.installer.ui.theme.material.ThemeMode
+import com.rosan.installer.util.AppLanguageManager
 import com.rosan.installer.util.hasFlag
 import org.koin.compose.koinInject
 import top.yukonga.miuix.kmp.basic.BasicComponent
@@ -371,6 +372,30 @@ fun MiuixNavigationItemWidget(
         summary = description,
         insideMargin = insideMargin,
         onClick = onClick
+    )
+}
+
+@Composable
+fun MiuixAppLanguageWidget() {
+    val context = LocalContext.current
+    var selectedLanguageTag by remember { mutableStateOf(AppLanguageManager.getSelectedLanguageTag()) }
+    val languageTags = AppLanguageManager.supportedLanguageTags
+    val labels = languageTags.map { AppLanguageManager.displayName(context, it) }
+    val selectedIndex = languageTags.indexOf(selectedLanguageTag).coerceAtLeast(0)
+    val entries = labels.map { SpinnerEntry(title = it) }
+
+    WindowSpinnerPreference(
+        title = stringResource(R.string.app_language),
+        summary = labels[selectedIndex],
+        items = entries,
+        selectedIndex = selectedIndex,
+        onSelectedIndexChange = { index ->
+            val languageTag = languageTags[index]
+            if (selectedLanguageTag != languageTag) {
+                AppLanguageManager.setSelectedLanguageTag(languageTag)
+                selectedLanguageTag = languageTag
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
@@ -181,6 +181,7 @@ fun MiuixPreferredPage(
                             navigator.push(Route.UninstallerGlobal)
                         }
                     )
+                    MiuixAppLanguageWidget()
                 }
             }
             if (uiState.authorizer == Authorizer.None)

--- a/app/src/main/java/com/rosan/installer/util/LocaleUtil.kt
+++ b/app/src/main/java/com/rosan/installer/util/LocaleUtil.kt
@@ -1,5 +1,11 @@
 package com.rosan.installer.util
 
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import com.rosan.installer.R
+import java.util.Locale
+
 /**
  * Converts legacy Android language codes to their modern equivalents.
  * This ensures compatibility with older and non-standard APK splits.
@@ -21,3 +27,57 @@ fun String.convertLegacyLanguageCode(): String =
         "tl" -> "fil" // Tagalog -> Filipino
         else -> this
     }
+
+object AppLanguageManager {
+    const val FOLLOW_SYSTEM = ""
+
+    val supportedLanguageTags = listOf(
+        FOLLOW_SYSTEM,
+        "en",
+        "ar",
+        "de",
+        "es",
+        "fr",
+        "hu",
+        "id",
+        "ja",
+        "nl",
+        "pt-BR",
+        "ru",
+        "th",
+        "tr",
+        "uk",
+        "vi",
+        "zh-CN",
+        "zh-TW"
+    )
+
+    fun getSelectedLanguageTag(): String =
+        normalizeLanguageTag(
+            AppCompatDelegate.getApplicationLocales()
+                .toLanguageTags()
+                .substringBefore(',')
+        )
+
+    fun setSelectedLanguageTag(languageTag: String) {
+        val normalizedTag = normalizeLanguageTag(languageTag)
+        val locales = if (normalizedTag == FOLLOW_SYSTEM) {
+            LocaleListCompat.getEmptyLocaleList()
+        } else {
+            LocaleListCompat.forLanguageTags(normalizedTag)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
+
+    fun displayName(context: Context, languageTag: String): String {
+        if (languageTag == FOLLOW_SYSTEM) return context.getString(R.string.app_language_follow_system)
+
+        val locale = Locale.forLanguageTag(languageTag)
+        return locale.getDisplayName(locale).replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase(locale) else it.toString()
+        }
+    }
+
+    private fun normalizeLanguageTag(languageTag: String): String =
+        supportedLanguageTags.firstOrNull { it.equals(languageTag, ignoreCase = true) } ?: FOLLOW_SYSTEM
+}

--- a/app/src/main/res/values-night-v29/themes.xml
+++ b/app/src/main/res/values-night-v29/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
     </style>
 

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:windowSplashScreenBackground">@android:color/background_dark</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.Installer" parent="Theme.AppCompat.NoActionBar" />
 
     <style name="Theme.Installer.Translucent.AppCompat" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.DeviceDefault.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.Light.NoActionBar">
         <!--    Compat Navigation Bar Color when ModalBottomSheet activated    -->
         <item name="android:enforceNavigationBarContrast">false</item>
     </style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Installer" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowSplashScreenBackground">@android:color/background_light</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
     </style>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -125,6 +125,8 @@
     <string name="installer_settings_desc">更改安装器的全局设置</string>
     <string name="uninstaller_settings">卸载器设置</string>
     <string name="uninstaller_settings_desc">更改卸载器的全局设置</string>
+    <string name="app_language">语言</string>
+    <string name="app_language_follow_system">跟随系统语言</string>
     <string name="installer_settings_global_installer">全局</string>
     <string name="installer_settings_require_biometric_auth">安装需要通过设备生物认证</string>
     <string name="installer_settings_require_biometric_auth_desc">在安装时请求系统进行生物识别认证</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -588,6 +588,8 @@
     <string name="get_update_directly_desc">直接從 GitHub 下載並安裝更新，不會留下任何快取</string>
     <string name="uninstaller_settings">卸載器設定</string>
     <string name="uninstaller_settings_desc">變更解除安裝器的全域設定</string>
+    <string name="app_language">語言</string>
+    <string name="app_language_follow_system">跟隨系統語言</string>
     <string name="config_customize_install_reason">自訂安裝原因</string>
     <string name="config_customize_install_reason_desc">指定安裝原因。對於新安裝的應用程式，選擇「使用者」通常會觸發啟動器自動建立桌面圖示</string>
     <string name="config_install_reason">安裝原因</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="installer_settings_desc">Change the global settings of the installer</string>
     <string name="uninstaller_settings">Uninstaller Settings</string>
     <string name="uninstaller_settings_desc">Change the global settings of the uninstaller</string>
+    <string name="app_language">Language</string>
+    <string name="app_language_follow_system">Follow system language</string>
     <string name="installer_settings_global_installer">Global</string>
     <string name="installer_settings_require_biometric_auth">Require Biometric Auth to Install</string>
     <string name="installer_settings_require_biometric_auth_desc">Require biometric auth when installing packages</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Installer" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Installer" parent="Theme.AppCompat.Light.NoActionBar" />
 
     <style name="Theme.Installer.Translucent" parent="Theme.Installer">
         <item name="android:windowIsTranslucent">true</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "abo
 
 [libraries]
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.7.1" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.18.0" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.13.0" }


### PR DESCRIPTION
## Summary
- Add an in-app language picker below Uninstaller Settings in Preferences.
- Support Follow system language and all locales declared by locales_config.xml.
- Apply selected app language on Android 12 and below via localized base contexts, while Android 13+ uses the platform LocaleManager.

## Why
Fixes #549 by giving Android 12 and older users an in-app language selector, where the system App language screen is unavailable.

## Verification
- ./gradlew.bat --no-daemon :app:assembleOnlineUnstableDebug