### PR TITLE
fix: 修复边衬区被重复消费的问题

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/SettingsPage.kt
@@ -133,7 +133,8 @@ fun Material3SettingsWideScreenLayout(
             mainPagerState = mainPagerState,
             tabs = tabs,
             useBlur = useBlur,
-            outerPadding = PaddingValues(0.dp) // Rail navigation doesn't overlay bottom content
+            outerPadding = PaddingValues(0.dp), // Rail navigation doesn't overlay bottom content
+            windowInsetsSides = WindowInsetsSides.Vertical + WindowInsetsSides.End
         )
     }
 }
@@ -148,7 +149,8 @@ private fun Material3SettingsPagerContent(
     mainPagerState: MainPagerState,
     tabs: List<NavigationTab>,
     useBlur: Boolean,
-    outerPadding: PaddingValues
+    outerPadding: PaddingValues,
+    windowInsetsSides: WindowInsetsSides? = null
 ) {
     HorizontalPager(
         state = mainPagerState.pagerState,
@@ -162,19 +164,22 @@ private fun Material3SettingsPagerContent(
                 title = tabs[page].label,
                 outerPadding = outerPadding,
                 configCount = configCount,
-                onNavigateToProfiles = { mainPagerState.animateToPage(1) }
+                onNavigateToProfiles = { mainPagerState.animateToPage(1) },
+                windowInsetsSides = windowInsetsSides
             )
 
             1 -> AllPage(
                 useBlur = useBlur,
                 title = tabs[page].label,
-                outerPadding = outerPadding
+                outerPadding = outerPadding,
+                windowInsetsSides = windowInsetsSides
             )
 
             2 -> PreferredPage(
                 useBlur = useBlur,
                 title = tabs[page].label,
-                outerPadding = outerPadding
+                outerPadding = outerPadding,
+                windowInsetsSides = windowInsetsSides
             )
         }
     }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/config/all/AllPage.kt
@@ -11,14 +11,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -26,6 +25,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -67,7 +67,8 @@ fun AllPage(
     useBlur: Boolean,
     viewModel: AllViewModel = koinViewModel { parametersOf(navigator) },
     title: String,
-    outerPadding: PaddingValues = PaddingValues(0.dp)
+    outerPadding: PaddingValues = PaddingValues(0.dp),
+    windowInsetsSides: WindowInsetsSides? = null
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigator = navigator
@@ -106,7 +107,6 @@ fun AllPage(
     DeleteEventCollector(viewModel, snackBarHostState)
 
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -115,11 +115,19 @@ fun AllPage(
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
+            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = TopAppBarDefaults.windowInsets.add(WindowInsets(left = 12.dp)),
-                title = { Text(title) },
+                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
+                    ?: TopAppBarDefaults.windowInsets,
+                title = {
+                    Text(
+                        text = title,
+                        modifier = Modifier.padding(start = 12.dp)
+                    )
+                },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = backdrop.getMaterial3AppBarColor(),
@@ -130,10 +138,11 @@ fun AllPage(
         },
         floatingActionButton = {
             AnimatedVisibility(
-                modifier = Modifier.padding(
-                    end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
-                    bottom = outerPadding.calculateBottomPadding()
-                ),
+                modifier = Modifier
+                    .padding(
+                        bottom = outerPadding.calculateBottomPadding()
+                    )
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.End)),
                 visible = showFloating,
                 enter = scaleIn(),
                 exit = scaleOut()
@@ -202,8 +211,12 @@ fun AllPage(
                         contentPadding = PaddingValues(
                             top = innerPadding.calculateTopPadding() + 16.dp,
                             bottom = outerPadding.calculateBottomPadding() + 16.dp,
-                            start = 16.dp + horizontalSafeInsets.calculateStartPadding(layoutDirection),
-                            end = 16.dp + horizontalSafeInsets.calculateEndPadding(layoutDirection)
+                            start = 16.dp + innerPadding.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
+                                layoutDirection
+                            ),
+                            end = 16.dp + innerPadding.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
+                                layoutDirection
+                            )
                         )
                     )
                 }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/home/HomePage.kt
@@ -7,10 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -31,6 +27,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -70,12 +67,12 @@ fun HomePage(
     title: String,
     outerPadding: PaddingValues,
     configCount: Int = 0,
-    onNavigateToProfiles: () -> Unit = {}
+    onNavigateToProfiles: () -> Unit = {},
+    windowInsetsSides: WindowInsetsSides? = null
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
     OnLifecycleEvent(event = Lifecycle.Event.ON_RESUME) {
@@ -87,11 +84,19 @@ fun HomePage(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
+            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = TopAppBarDefaults.windowInsets.add(WindowInsets(left = 12.dp)),
-                title = { Text(title) },
+                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
+                    ?: TopAppBarDefaults.windowInsets,
+                title = {
+                    Text(
+                        text = title,
+                        modifier = Modifier.padding(start = 12.dp)
+                    )
+                },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = backdrop.getMaterial3AppBarColor(),
@@ -106,9 +111,13 @@ fun HomePage(
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
             contentPadding = PaddingValues(
-                start = 16.dp + horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                start = 16.dp + paddingValues.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
+                    layoutDirection
+                ),
                 top = paddingValues.calculateTopPadding() + 16.dp,
-                end = 16.dp + horizontalSafeInsets.calculateEndPadding(layoutDirection),
+                end = 16.dp + paddingValues.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
+                    layoutDirection
+                ),
                 bottom = outerPadding.calculateBottomPadding()
             )
         ) {

--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/PreferredPage.kt
@@ -5,22 +5,19 @@ package com.rosan.installer.ui.page.main.settings.preferred
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.add
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -70,6 +67,7 @@ fun PreferredPage(
     viewModel: PreferredViewModel = koinViewModel(),
     title: String,
     outerPadding: PaddingValues = PaddingValues(0.dp),
+    windowInsetsSides: WindowInsetsSides? = null
 ) {
     val context = LocalContext.current
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -117,7 +115,6 @@ fun PreferredPage(
     }
 
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val backdrop = rememberMaterial3BlurBackdrop(useBlur)
 
@@ -126,11 +123,19 @@ fun PreferredPage(
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentWindowInsets = windowInsetsSides?.let { ScaffoldDefaults.contentWindowInsets.only(it) }
+            ?: ScaffoldDefaults.contentWindowInsets,
         topBar = {
             LargeFlexibleTopAppBar(
                 modifier = Modifier.installerMaterial3BlurEffect(backdrop),
-                windowInsets = TopAppBarDefaults.windowInsets.add(WindowInsets(left = 12.dp)),
-                title = { Text(title) },
+                windowInsets = windowInsetsSides?.let { TopAppBarDefaults.windowInsets.only(it) }
+                    ?: TopAppBarDefaults.windowInsets,
+                title = {
+                    Text(
+                        text = title,
+                        modifier = Modifier.padding(start = 12.dp)
+                    )
+                },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = backdrop.getMaterial3AppBarColor(),
@@ -151,9 +156,13 @@ fun PreferredPage(
                 .fillMaxSize()
                 .then(backdrop?.let { Modifier.layerBackdrop(it) } ?: Modifier),
             contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                start = paddingValues.calculateStartPadding(layoutDirection) + outerPadding.calculateStartPadding(
+                    layoutDirection
+                ),
                 top = paddingValues.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
+                end = paddingValues.calculateEndPadding(layoutDirection) + outerPadding.calculateEndPadding(
+                    layoutDirection
+                ),
                 bottom = outerPadding.calculateBottomPadding()
             )
         ) {

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/config/all/MiuixAllPage.kt
@@ -9,17 +9,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -113,7 +108,6 @@ fun MiuixAllPage(
     }
 
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val topBarBackdrop = rememberMiuixBlurBackdrop(enableBlur)
 
@@ -169,8 +163,8 @@ fun MiuixAllPage(
                         .nestedScroll(scrollBehavior.nestedScrollConnection),
                     columns = GridCells.Adaptive(350.dp),
                     contentPadding = PaddingValues(
-                        start = horizontalSafeInsets.calculateStartPadding(layoutDirection) + 16.dp,
-                        end = horizontalSafeInsets.calculateEndPadding(layoutDirection) + 16.dp,
+                        start = innerPadding.calculateStartPadding(layoutDirection) + 16.dp,
+                        end = innerPadding.calculateEndPadding(layoutDirection) + 16.dp,
                         top = innerPadding.calculateTopPadding() + 16.dp,
                         bottom = outerPadding.calculateBottomPadding() + 16.dp
                     ),

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/home/MiuixHomePage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/home/MiuixHomePage.kt
@@ -9,18 +9,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -92,7 +87,6 @@ fun MiuixHomePage(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val scrollBehavior = MiuixScrollBehavior()
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     OnLifecycleEvent(event = Lifecycle.Event.ON_RESUME) {
         viewModel.dispatch(HomePageViewAction.RefreshActivateStatus)
@@ -133,9 +127,9 @@ fun MiuixHomePage(
                 .overScrollVertical()
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
             contentPadding = PaddingValues(
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection) + 12.dp,
+                start = innerPadding.calculateStartPadding(layoutDirection) + 12.dp,
                 top = innerPadding.calculateTopPadding() + 12.dp,
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection) + 12.dp,
+                end = innerPadding.calculateEndPadding(layoutDirection) + 12.dp,
                 bottom = outerPadding.calculateBottomPadding()
             ),
             overscrollEffect = null

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/MiuixPreferredPage.kt
@@ -5,15 +5,10 @@ package com.rosan.installer.ui.page.miuix.settings.preferred
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
@@ -89,7 +84,11 @@ fun MiuixPreferredPage(
     }
     val scrollBehavior = MiuixScrollBehavior()
 
-    var errorDialogInfo by remember { mutableStateOf<PreferredViewEvent.ShowDefaultInstallerErrorDetail?>(null) }
+    var errorDialogInfo by remember {
+        mutableStateOf<PreferredViewEvent.ShowDefaultInstallerErrorDetail?>(
+            null
+        )
+    }
     val showErrorSheetState = remember { mutableStateOf(false) }
 
     val defaultInstallerErrorDetailActionLabel = stringResource(R.string.details)
@@ -118,7 +117,6 @@ fun MiuixPreferredPage(
 
     // Capture layout direction and horizontal safe insets for display cutouts in landscape
     val layoutDirection = LocalLayoutDirection.current
-    val horizontalSafeInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal).asPaddingValues()
 
     val topBarBackdrop = rememberMiuixBlurBackdrop(enableBlur)
 
@@ -143,9 +141,9 @@ fun MiuixPreferredPage(
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
             contentPadding = PaddingValues(
                 // Safely add horizontal paddings to avoid notches in landscape
-                start = horizontalSafeInsets.calculateStartPadding(layoutDirection),
+                start = innerPadding.calculateStartPadding(layoutDirection),
                 top = innerPadding.calculateTopPadding(),
-                end = horizontalSafeInsets.calculateEndPadding(layoutDirection),
+                end = innerPadding.calculateEndPadding(layoutDirection),
                 bottom = outerPadding.calculateBottomPadding()
             ),
             overscrollEffect = null
@@ -186,8 +184,9 @@ fun MiuixPreferredPage(
             }
             if (uiState.authorizer == Authorizer.None)
                 item {
-                    val tip = if (capabilityProvider.isSystemApp) stringResource(R.string.config_authorizer_none_system_app_tips)
-                    else stringResource(R.string.config_authorizer_none_tips)
+                    val tip =
+                        if (capabilityProvider.isSystemApp) stringResource(R.string.config_authorizer_none_system_app_tips)
+                        else stringResource(R.string.config_authorizer_none_tips)
                     MiuixSettingsTipCard(text = tip)
                 }
             item { SmallTitle(stringResource(R.string.basic)) }


### PR DESCRIPTION
## 变更概述

修复主页、配置与设置页面在横屏时重复消费了已被侧边导航栏消费的边衬区的问题

旧：
<img width="2460" height="1080" alt="Screenshot_20260509-194017_InstallerX Revived" src="https://github.com/user-attachments/assets/f28895ba-85a5-409a-8eff-aac456b7b703" />
新：
<img width="2460" height="1080" alt="Screenshot_20260509-194005_InstallerX Revived" src="https://github.com/user-attachments/assets/25ccf8e1-6b1a-4a51-a84d-f25ed8a3ac64" />
