### PR TITLE
fix: replace BackHandler with NavigationBackHandler to prevent animation freeze

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/navigation/MainScreenBackHandler.kt
+++ b/app/src/main/java/com/rosan/installer/ui/navigation/MainScreenBackHandler.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (C) 2026 InstallerX Revived contributors
+
+// Portions of this file are derived from weishu/KernelSU
+// (https://github.com/tiann/KernelSU)
+// Copyright (C) KernelSU contributors
+// Licensed under GPL-3.0
+package com.rosan.installer.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
+
+@Composable
+fun MainScreenBackHandler(
+    mainPagerState: MainPagerState,
+    navController: Navigator,
+) {
+    val isPagerBackHandlerEnabled by remember {
+        derivedStateOf {
+            navController.current() is Route.Main && navController.backStackSize() == 1 && mainPagerState.selectedPage != 0
+        }
+    }
+
+    val navEventState = rememberNavigationEventState(NavigationEventInfo.None)
+    val onBackCompleted: () -> Unit = { mainPagerState.animateToPage(0) }
+
+    NavigationBackHandler(
+        state = navEventState,
+        isBackEnabled = isPagerBackHandlerEnabled,
+        onBackCompleted = onBackCompleted
+    )
+}

--- a/app/src/main/java/com/rosan/installer/ui/navigation/Material3NavWrapper.kt
+++ b/app/src/main/java/com/rosan/installer/ui/navigation/Material3NavWrapper.kt
@@ -2,7 +2,6 @@
 // Copyright (C) 2023-2026 iamr0s, InstallerX Revived contributors
 package com.rosan.installer.ui.navigation
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -75,9 +74,10 @@ fun Material3MainPageWrapper(
             sharedViewModel.updateLastMainPageIndex(settledPage)
         }
     }
-    BackHandler(enabled = mainPagerState.selectedPage != 0) {
-        mainPagerState.animateToPage(0)
-    }
+    MainScreenBackHandler(
+        mainPagerState = mainPagerState,
+        navController = LocalNavigator.current,
+    )
 
     val layoutInfo = LocalWindowLayoutInfo.current
     val showRail = layoutInfo.showNavigationRail

--- a/app/src/main/java/com/rosan/installer/ui/navigation/MiuixNavWrapper.kt
+++ b/app/src/main/java/com/rosan/installer/ui/navigation/MiuixNavWrapper.kt
@@ -3,7 +3,6 @@
 package com.rosan.installer.ui.navigation
 
 import android.os.Build
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.RoomPreferences
@@ -80,9 +79,10 @@ fun MiuixMainPageWrapper(
             sharedViewModel.updateLastMainPageIndex(settledPage)
         }
     }
-    BackHandler(enabled = mainPagerState.selectedPage != 0) {
-        mainPagerState.animateToPage(0)
-    }
+    MainScreenBackHandler(
+        mainPagerState = mainPagerState,
+        navController = LocalNavigator.current,
+    )
 
     val snackbarHostState = remember { SnackbarHostState() }
 


### PR DESCRIPTION
Replace BackHandler with NavigationBackHandler to fix animation conflict

The previous implementation mistakenly used BackHandler, which bypasses 
NavDisplay's predictive back animation pipeline. This caused the pager 
scroll animation to conflict with the system's back gesture transition.

- Replace BackHandler with NavigationBackHandler for NavDisplay integration.
- Extract back handling logic into MainScreenBackHandler.kt to separate 
  concerns from PagerState.

My bad for the oversight in the previous commit.