### PR TITLE
refactor: restrict API-specific theme settings and remove legacy blur warning

### DIFF
--- a/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/settings/preferred/theme/ThemeSettingsPage.kt
@@ -70,7 +70,6 @@ import com.rosan.installer.domain.settings.model.PredictiveBackExitDirection
 import com.rosan.installer.ui.icons.AppIcons
 import com.rosan.installer.ui.navigation.LocalNavigator
 import com.rosan.installer.ui.page.main.widget.card.ColorSwatchPreview
-import com.rosan.installer.ui.page.main.widget.dialog.BlurWarningDialog
 import com.rosan.installer.ui.page.main.widget.dialog.HideLauncherIconWarningDialog
 import com.rosan.installer.ui.page.main.widget.setting.BaseItemContainer
 import com.rosan.installer.ui.page.main.widget.setting.BaseWidget
@@ -100,7 +99,6 @@ fun ThemeSettingsPage(
     var showHideLauncherIconDialog by remember { mutableStateOf(false) }
     var showPaletteDialog by remember { mutableStateOf(false) }
     var showThemeModeDialog by remember { mutableStateOf(false) }
-    var showBlurWarningDialog by remember { mutableStateOf(false) }
     var showPredictiveBackAnimationDialog by remember { mutableStateOf(false) }
     var showPredictiveBackExitDirectionDialog by remember { mutableStateOf(false) }
     val transition = LocalNavAnimatedContentScope.current.transition
@@ -165,15 +163,6 @@ fun ThemeSettingsPage(
         onConfirm = {
             showHideLauncherIconDialog = false
             viewModel.dispatch(ThemeSettingsAction.ChangeShowLauncherIcon(false))
-        }
-    )
-
-    BlurWarningDialog(
-        show = showBlurWarningDialog,
-        onDismiss = { showBlurWarningDialog = false },
-        onConfirm = {
-            showBlurWarningDialog = false
-            viewModel.dispatch(ThemeSettingsAction.SetUseBlur(true))
         }
     )
 
@@ -277,20 +266,16 @@ fun ThemeSettingsPage(
                 SegmentedColumn(
                     title = stringResource(R.string.theme_settings_google_ui)
                 ) {
-                    item {
-                        SwitchWidget(
-                            icon = AppIcons.Blur,
-                            title = stringResource(R.string.theme_settings_use_blur),
-                            description = stringResource(R.string.theme_settings_use_blur_desc),
-                            checked = uiState.useBlur,
-                            onCheckedChange = { isChecked ->
-                                if (isChecked && Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-                                    showBlurWarningDialog = true
-                                } else {
-                                    viewModel.dispatch(ThemeSettingsAction.SetUseBlur(isChecked))
-                                }
-                            }
-                        )
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        item {
+                            SwitchWidget(
+                                icon = AppIcons.Blur,
+                                title = stringResource(R.string.theme_settings_use_blur),
+                                description = stringResource(R.string.theme_settings_use_blur_desc),
+                                checked = uiState.useBlur,
+                                onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.SetUseBlur(it)) }
+                            )
+                        }
                     }
                     item {
                         BaseWidget(
@@ -418,16 +403,18 @@ fun ThemeSettingsPage(
             }
 
             // --- Group 4: Predictive Back ---
-            item {
-                SegmentedColumn(
-                    title = stringResource(R.string.theme_settings_predictive_back)
-                ) {
-                    item { PredictiveBackAnimationWidget(uiState) { showPredictiveBackAnimationDialog = true } }
-                    item(
-                        animatedVisibility = uiState.predictiveBackAnimation == PredictiveBackAnimation.Scale ||
-                                uiState.predictiveBackAnimation == PredictiveBackAnimation.AOSP
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                item {
+                    SegmentedColumn(
+                        title = stringResource(R.string.theme_settings_predictive_back)
                     ) {
-                        PredictiveBackAnimationDirectionWidget(uiState) { showPredictiveBackExitDirectionDialog = true }
+                        item { PredictiveBackAnimationWidget(uiState) { showPredictiveBackAnimationDialog = true } }
+                        item(
+                            animatedVisibility = uiState.predictiveBackAnimation == PredictiveBackAnimation.Scale ||
+                                    uiState.predictiveBackAnimation == PredictiveBackAnimation.AOSP
+                        ) {
+                            PredictiveBackAnimationDirectionWidget(uiState) { showPredictiveBackExitDirectionDialog = true }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/main/widget/dialog/AlertDialog.kt
@@ -435,33 +435,3 @@ fun CustomGithubProxyUrlDialog(
         }
     )
 }
-
-/**
- * A dialog to warn the user about unstable blur effects on Android 11 and below.
- */
-@Composable
-fun BlurWarningDialog(
-    show: Boolean,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-) {
-    if (show) {
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            title = { Text(text = stringResource(R.string.warning)) },
-            text = {
-                Text(text = stringResource(R.string.theme_settings_use_blur_warning))
-            },
-            confirmButton = {
-                TextButton(onClick = onConfirm) {
-                    Text(text = stringResource(R.string.confirm))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = onDismiss) {
-                    Text(text = stringResource(R.string.cancel))
-                }
-            }
-        )
-    }
-}

--- a/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/theme/MiuixThemeSettingsPage.kt
+++ b/app/src/main/java/com/rosan/installer/ui/page/miuix/settings/preferred/theme/MiuixThemeSettingsPage.kt
@@ -92,7 +92,6 @@ fun MiuixThemeSettingsPage(
     val transition = LocalNavAnimatedContentScope.current.transition
 
     val showHideLauncherIconDialog = remember { mutableStateOf(false) }
-    val showBlurWarningDialog = remember { mutableStateOf(false) }
 
     MiuixHideLauncherIconWarningDialog(
         showState = showHideLauncherIconDialog,
@@ -100,15 +99,6 @@ fun MiuixThemeSettingsPage(
         onConfirm = {
             showHideLauncherIconDialog.value = false
             viewModel.dispatch(ThemeSettingsAction.ChangeShowLauncherIcon(false))
-        }
-    )
-
-    MiuixBlurWarningDialog(
-        showState = showBlurWarningDialog,
-        onDismiss = { showBlurWarningDialog.value = false },
-        onConfirm = {
-            showBlurWarningDialog.value = false
-            viewModel.dispatch(ThemeSettingsAction.SetUseBlur(true))
         }
     )
 
@@ -181,18 +171,14 @@ fun MiuixThemeSettingsPage(
                             viewModel.dispatch(ThemeSettingsAction.SetThemeMode(newMode))
                         }
                     )
-                    MiuixSwitchWidget(
-                        title = stringResource(R.string.theme_settings_use_blur),
-                        description = stringResource(R.string.theme_settings_use_blur_desc),
-                        checked = uiState.useBlur,
-                        onCheckedChange = { isChecked ->
-                            if (isChecked && Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-                                showBlurWarningDialog.value = true
-                            } else {
-                                viewModel.dispatch(ThemeSettingsAction.SetUseBlur(isChecked))
-                            }
-                        }
-                    )
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        MiuixSwitchWidget(
+                            title = stringResource(R.string.theme_settings_use_blur),
+                            description = stringResource(R.string.theme_settings_use_blur_desc),
+                            checked = uiState.useBlur,
+                            onCheckedChange = { viewModel.dispatch(ThemeSettingsAction.SetUseBlur(it)) }
+                        )
+                    }
                     MiuixSwitchWidget(
                         title = stringResource(R.string.theme_settings_miuix_custom_colors),
                         description = stringResource(R.string.theme_settings_miuix_custom_colors_desc),
@@ -338,46 +324,48 @@ fun MiuixThemeSettingsPage(
             }
 
             // Predictive Back Section
-            item { SmallTitle(stringResource(R.string.theme_settings_predictive_back)) }
-            item {
-                Card(
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(bottom = 12.dp)
-                ) {
-                    MiuixPredictiveBackAnimationWidget(
-                        currentAnimation = uiState.predictiveBackAnimation,
-                        onAnimationChange = { newAnim ->
-                            // Hey Google
-                            // Why you keep playing the animation even we are already play completed?
-                            // This is very dirty, We are using RestrictedApi, but we don't have other choice
-                            transition.setPlaytimeAfterInitialAndTargetStateEstablished(
-                                transition.targetState,
-                                transition.targetState,
-                                transition.playTimeNanos
-                            )
-
-                            viewModel.dispatch(ThemeSettingsAction.SetPredictiveBackAnimation(newAnim))
-                        }
-                    )
-
-                    AnimatedVisibility(
-                        visible = uiState.predictiveBackAnimation == PredictiveBackAnimation.Scale ||
-                                uiState.predictiveBackAnimation == PredictiveBackAnimation.AOSP,
-                        enter = fadeIn() + expandVertically(),
-                        exit = fadeOut() + shrinkVertically()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                item { SmallTitle(stringResource(R.string.theme_settings_predictive_back)) }
+                item {
+                    Card(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .padding(bottom = 12.dp)
                     ) {
-                        MiuixPredictiveBackExitDirectionWidget(
-                            currentDirection = uiState.predictiveBackExitDirection,
-                            onDirectionChange = {
+                        MiuixPredictiveBackAnimationWidget(
+                            currentAnimation = uiState.predictiveBackAnimation,
+                            onAnimationChange = { newAnim ->
+                                // Hey Google
+                                // Why you keep playing the animation even we are already play completed?
+                                // This is very dirty, We are using RestrictedApi, but we don't have other choice
                                 transition.setPlaytimeAfterInitialAndTargetStateEstablished(
                                     transition.targetState,
                                     transition.targetState,
                                     transition.playTimeNanos
                                 )
-                                viewModel.dispatch(ThemeSettingsAction.SetPredictiveBackExitDirection(it))
+
+                                viewModel.dispatch(ThemeSettingsAction.SetPredictiveBackAnimation(newAnim))
                             }
                         )
+
+                        AnimatedVisibility(
+                            visible = uiState.predictiveBackAnimation == PredictiveBackAnimation.Scale ||
+                                    uiState.predictiveBackAnimation == PredictiveBackAnimation.AOSP,
+                            enter = fadeIn() + expandVertically(),
+                            exit = fadeOut() + shrinkVertically()
+                        ) {
+                            MiuixPredictiveBackExitDirectionWidget(
+                                currentDirection = uiState.predictiveBackExitDirection,
+                                onDirectionChange = {
+                                    transition.setPlaytimeAfterInitialAndTargetStateEstablished(
+                                        transition.targetState,
+                                        transition.targetState,
+                                        transition.playTimeNanos
+                                    )
+                                    viewModel.dispatch(ThemeSettingsAction.SetPredictiveBackExitDirection(it))
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -552,52 +540,6 @@ private fun MiuixHideLauncherIconWarningDialog(
                         onClick = onConfirm,
                         text = stringResource(R.string.confirm),
                         colors = ButtonDefaults.textButtonColorsPrimary() // Apply primary color style
-                    )
-                }
-            }
-        }
-    )
-}
-
-/**
- * A miuix-style dialog to warn the user about unstable blur effects on Android 11 and below.
- */
-@Composable
-fun MiuixBlurWarningDialog(
-    showState: MutableState<Boolean>,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
-) {
-    WindowDialog(
-        show = showState.value,
-        onDismissRequest = onDismiss,
-        title = stringResource(R.string.warning),
-        content = {
-            Column {
-                Text(
-                    text = stringResource(R.string.theme_settings_use_blur_warning),
-                    color = MiuixTheme.colorScheme.onSurface
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    TextButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = onDismiss,
-                        text = stringResource(R.string.cancel)
-                    )
-
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    TextButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = onConfirm,
-                        text = stringResource(R.string.confirm),
-                        colors = ButtonDefaults.textButtonColorsPrimary()
                     )
                 }
             }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -487,6 +487,5 @@
     <string name="dhizuku_not_available">يرجى تفعيل Dhizuku</string>
     <string name="theme_settings_use_apple_floating_bar_desc">اعرض شريط تنقل عائم في أسفل الشاشة</string>
     <string name="theme_settings_use_blur_desc">قم بتفعيل خاصية التمويه للتطبيق</string>
-    <string name="theme_settings_use_blur_warning">قد يكون تأثير التمويه غير مستقر ويسبب مشاكل غير متوقعة على نظام Android 11 والإصدارات الأقدم. قد تحتاج إلى مسح بيانات التطبيق في حال حدوث مشاكل. هل تريد المتابعة؟</string>
     <string name="theme_settings_color_spec">مواصفات اللون</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -682,7 +682,6 @@
     <string name="installer_live_channel_name_desc">Mostrar el progreso de la instalación como actualización en vivo</string>
     <string name="installer_live_channel_short_text_pending_install">Pendiente</string>
     <string name="exception_zip_exception">No se ha conseguido abrir zip como archivo</string>
-    <string name="theme_settings_use_blur_warning">El efecto de desenfoque puede ser inestable y causar problemas inesperados en Android 11 y versiones posteriores. Puede que necesites borrar los datos de la app si surgen problemas. ¿Quieres continuar?</string>
     <string name="tag_downgrade">Degradación</string>
     <string name="tag_signature">Firma</string>
     <string name="tag_arch_32">32-Bit</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -61,7 +61,6 @@
     <string name="theme_settings_use_expressive_ui_desc">استفاده از سبک جدید M3 Expressive</string>
     <string name="theme_settings_use_blur">فعال‌سازی حالت محو</string>
     <string name="theme_settings_use_blur_desc">فعال‌سازی حالت محو برای برنامه</string>
-    <string name="theme_settings_use_blur_warning">اثر حالت محو ممکن است ناپایدار باشد و باعث بروز مشکلات غیرمنتظره در اندروید ۱۱ و نسخه‌های پایین‌تر شود. در صورت بروز مشکل، ممکن است نیاز باشد داده‌های برنامه را پاک کنید. آیا می‌خواهید ادامه دهید؟</string>
     <string name="theme_settings_google_ui_style">سبک رابط کاربری گوگل</string>
     <string name="theme_settings_theme_mode">حالت پوسته</string>
     <string name="theme_settings_theme_mode_desc">انتخاب حالت پوسته</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -573,7 +573,6 @@
     <string name="installer_settings_auto_clear_time_never_desc">Ne jamais effacer la notification de réussite de l\'installation</string>
     <string name="installer_settings_auto_clear_time_seconds_format">%d secondes</string>
     <string name="installer_settings_auto_clear_time_seconds_format_desc">Effacer la notification de réussite de l\'installation après %d secondes</string>
-    <string name="theme_settings_use_blur_warning">L\'effet de flou peut être instable et causer des problèmes inattendus sur Android 11 et les versions antérieures. Vous devrez peut-être effacer les données de l\'application si des problèmes surviennent. Voulez-vous continuer ?</string>
     <string name="config_authorizer_none_system_app_tips">En tant qu\'installateur système, la plupart des options ici ne sont pas nécessaires.</string>
     <string name="config_install_mode_desc">Mode d\'installation par défaut et paramètres associés</string>
     <string name="config_install_reason">Raison de l\'installation</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -513,7 +513,6 @@
     <string name="export_logs_desc">Ekspor catatan aplikasi</string>
     <string name="theme_settings_use_blur">Aktifkan Blur</string>
     <string name="theme_settings_use_blur_desc">Aktifkan blur untuk aplikasi</string>
-    <string name="theme_settings_use_blur_warning">Efek blur mungkin tidak stabil dan menyebabkan masalah tak terduga pada Android 11 dan di bawahnya. Anda mungkin perlu menghapus data aplikasi jika masalah terjadi. Apakah Anda ingin melanjutkan?</string>
     <string name="config_authorizer_none_system_app_tips">Berjalan sebagai penginstal paket sistem, sebagian besar opsi tidak diperlukan.</string>
     <string name="config_auto_delete_zip">Hapus berkas zip secara otomatis</string>
     <string name="config_auto_delete_zip_desc">Selain menghapus paket instalasi, juga hapus file terkompresi yang berisi paket instalasi.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -658,7 +658,6 @@
     <string name="tag_downgrade">ダウングレード</string>
     <string name="tag_arch_32">32 ビット</string>
     <string name="app_version_info_format">%1$s %2$s %3$s (%4$s)</string>
-    <string name="theme_settings_use_blur_warning">Android 11 以前では、ぼかし効果が不安定になり、予期せぬ問題が発生する可能性があります。問題が発生した場合は、アプリデータを消去する必要があるかもしれません。続行してもよろしいですか？</string>
     <string name="installer_analyse_success">分析に成功しました</string>
     <string name="tag_signature">署名</string>
     <string name="installer_prepare_arch_32_notice">このアプリは 32 ビットモードで実行されます。これにより、64 ビットデバイスではメモリ使用量が増加したり、パフォーマンスが低下したりする可能性があります</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -678,7 +678,6 @@
     <string name="tag_arch_emulated">Geëmuleerde architectuur</string>
     <string name="installer_prepare_arch_32_notice">Deze app zal uitgevoerd worden in 32-bit modus. Dit kan geheugengebruik verhogen of prestaties verminderen op 64-bit apparaten</string>
     <string name="installer_prepare_arch_mismatch_notice">De apparchitectuur (%1$s) komt niet overeen met die van je apparaat (%2$s). Het zal daarom uitgevoerd worden via een vertaallaag. Installeren of uitvoeren van de app is niet gegarandeerd en problemen zoals oververhitten en crashes kunnen voorkomen</string>
-    <string name="theme_settings_use_blur_warning">Het vervagingseffect kan instabiel zijn en onverwachte problemen veroorzaken op Android 11 of lager. Mogelijk moet je de appgegevens wissen als er problemen zijn. Wil je doorgaan?</string>
     <string name="installer_analyse_success">Succesvolle analyse</string>
     <string name="installer_live_channel_short_text_analyse_failed">Mislukt</string>
     <string name="version_with_prefix_format">%1$s%2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -678,7 +678,6 @@
     <string name="installer_notification_desc">Notificação de serviço em segundo plano, inútil</string>
     <string name="installer_live_channel_name_desc">Mostrar o progresso da instalação em tempo real</string>
     <string name="installer_live_channel_short_text_pending_install">Pendente</string>
-    <string name="theme_settings_use_blur_warning">O efeito de desfoque pode ser instável e causar problemas inesperados no Android 11 e versões anteriores. Pode ser necessário limpar os dados do app se ocorrerem problemas. Deseja continuar?</string>
     <string name="installer_analyse_success">Sucesso na análise</string>
     <string name="installer_live_channel_short_text_analyse_failed">Falha</string>
     <string name="exception_resolve_failed_link_not_valid">Este link não contém um arquivo válido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -657,7 +657,6 @@
     <string name="export_logs_desc">Отправить журнал событий приложения</string>
     <string name="theme_settings_use_blur">Эффект размытия</string>
     <string name="theme_settings_use_blur_desc">Включить эффект размытия в приложении</string>
-    <string name="theme_settings_use_blur_warning">Эффект размытия может работать нестабильно и вызывать проблемы на Android 11 и более ранних версиях. При возникновении проблем может потребоваться очистка данных приложения. Продолжить?</string>
     <string name="config_authorizer_none_system_app_tips">При использовании в качестве системного установщика большинство указанных опций не требуются.</string>
     <string name="config_auto_delete_zip">Автоудаление zip-файлов</string>
     <string name="config_auto_delete_zip_desc">Удалить архив с содержащимся в нем установочным пакетом.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -612,7 +612,6 @@
     <string name="export_logs_desc">Uygulama günlüklerini dışa aktarır</string>
     <string name="theme_settings_use_blur">Bulanıklığı Etkinleştir</string>
     <string name="theme_settings_use_blur_desc">Uygulama için bulanıklığı etkinleştirir</string>
-    <string name="theme_settings_use_blur_warning">Bulanıklaştırma efekti, Android 11 ve altı sürümlerde kararsız olabilir ve beklenmedik sorunlara neden olabilir. Sorunlar oluşursa uygulama verilerini temizlemeniz gerekebilir. Devam etmek istiyor musunuz?</string>
     <string name="uninstaller_settings">Kaldırıcı Ayarları</string>
     <string name="uninstaller_settings_desc">Kaldırıcının genel ayarlarını değiştirin</string>
     <string name="installer_settings_require_biometric_auth">Yükleme için biyometrik kimlik doğrulama gerekli</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -270,7 +270,6 @@
     <string name="theme_settings_use_expressive_ui_desc">Використовуйте новий експресивний UI</string>
     <string name="theme_settings_use_blur">Увімкнути розмиття</string>
     <string name="theme_settings_use_blur_desc">Увімкніть розмиття для програми</string>
-    <string name="theme_settings_use_blur_warning">Ефект розмиття може бути нестабільним і викликати несподівані проблеми на Android 11 і старіших версіях. У разі виникнення проблем вам може знадобитися очистити дані програми. Ви хочете продовжити?</string>
     <string name="theme_settings_google_ui_style">Стиль Google UI</string>
     <string name="theme_settings_theme_mode">Стиль теми</string>
     <string name="theme_settings_theme_mode_desc">Виберіть стиль теми</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -63,7 +63,6 @@
     <string name="theme_settings_use_expressive_ui_desc">Sử dụng kiểu M3 Expressive mới</string>
     <string name="theme_settings_use_blur">Bật Mờ</string>
     <string name="theme_settings_use_blur_desc">Bật mờ cho ứng dụng</string>
-    <string name="theme_settings_use_blur_warning">Hiệu ứng mờ có thể không ổn định và gây ra các sự cố không mong muốn trên Android 11 trở xuống. Bạn có thể cần xoá dữ liệu ứng dụng nếu sự cố diễn ra. Bạn có muốn tiếp tục không?</string>
     <string name="theme_settings_google_ui_style">Kiểu UI Google</string>
     <string name="theme_settings_theme_mode">Chế độ Chủ đề</string>
     <string name="theme_settings_theme_mode_desc">Chọn chế độ chủ đề</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -91,7 +91,6 @@
     <string name="theme_settings_use_apple_floating_bar_desc">在屏幕底部使用悬浮样式的导航栏</string>
     <string name="theme_settings_use_blur">启用模糊</string>
     <string name="theme_settings_use_blur_desc">为应用启用模糊效果</string>
-    <string name="theme_settings_use_blur_warning">在 Android 11 及以下系统中，模糊效果不稳定并可能导致异常。如果出现问题，可能需要清除应用数据。是否继续启用？</string>
     <string name="theme_settings_google_ui_style">Google UI 风格</string>
     <string name="theme_settings_theme_mode">主题模式</string>
     <string name="theme_settings_theme_mode_desc">选择主题模式</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -666,7 +666,6 @@
     <string name="export_logs_desc">匯出應用程式日誌</string>
     <string name="theme_settings_use_blur">啟用模糊效果</string>
     <string name="theme_settings_use_blur_desc">為應用程式啟用模糊效果</string>
-    <string name="theme_settings_use_blur_warning">模糊效果在 Android 11 及以下版本可能不穩定，並可能導致非預期的問題。若發生異常，您可能需要清除應用程式資料。是否要繼續？</string>
     <string name="uninstaller_settings_require_biometric_auth">解除安裝時需進行生物辨識驗證</string>
     <string name="uninstaller_settings_require_biometric_auth_desc">解除安裝時需要進行系統指紋或臉部辨識驗證</string>
     <string name="use_biometric_confirm_change_auth_settings">您確定要更改此設定嗎</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,6 @@
     <string name="theme_settings_use_apple_floating_bar_desc">Display a floating style navigation bar at the bottom of the screen</string>
     <string name="theme_settings_use_blur">Enable Blur</string>
     <string name="theme_settings_use_blur_desc">Enable blur for the app</string>
-    <string name="theme_settings_use_blur_warning">The blur effect may be unstable and cause unexpected issues on Android 11 and below. You may need to clear app data if problems occur. Do you want to continue?</string>
     <string name="theme_settings_google_ui_style">Google UI style</string>
     <string name="theme_settings_theme_mode">Theme Mode</string>
     <string name="theme_settings_theme_mode_desc">Select theme mode</string>


### PR DESCRIPTION
- Restrict the "Enable Blur" setting to Android 12 (API 31) and higher.
- Restrict "Predictive Back" settings to Android 14 (API 34) and higher.
- Remove the `BlurWarningDialog` and its corresponding localized strings.