### PR TITLE
Fix installing private content URIs with privileged fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -250,4 +250,7 @@ dependencies {
     implementation(libs.focus.api)
 
     implementation(libs.materialKolor)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/PackageManagerUtil.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/PackageManagerUtil.kt
@@ -16,6 +16,10 @@ import com.rosan.installer.domain.engine.model.install.UninstallFlags
 object PackageManagerUtil {
     private const val EXTRA_LEGACY_STATUS = "android.content.pm.extra.LEGACY_STATUS"
 
+    fun interface ActivityStarter {
+        suspend fun start(intent: Intent)
+    }
+
     /**
      * Flag parameter to indicate keeping the package's data directory.
      */
@@ -33,7 +37,10 @@ object PackageManagerUtil {
 
     suspend fun installResultVerify(
         context: Context,
-        receiver: LocalIntentReceiver
+        receiver: LocalIntentReceiver,
+        activityStarter: ActivityStarter = ActivityStarter { intent ->
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
     ) {
         val intent = receiver.getResult()
         val status =
@@ -41,9 +48,8 @@ object PackageManagerUtil {
         val action =
             IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
 
-        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION && action != null) {
-            context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-            installResultVerify(context, receiver)
+        if (handlePendingUserAction(status, action, activityStarter)) {
+            installResultVerify(context, receiver, activityStarter)
             return
         }
 
@@ -58,9 +64,25 @@ object PackageManagerUtil {
         throw InstallException(errorType, ecpMsg)
     }
 
+    internal suspend fun handlePendingUserAction(
+        status: Int,
+        action: Intent?,
+        activityStarter: ActivityStarter
+    ): Boolean {
+        if (status != PackageInstaller.STATUS_PENDING_USER_ACTION || action == null) {
+            return false
+        }
+
+        activityStarter.start(action)
+        return true
+    }
+
     suspend fun uninstallResultVerify(
         context: Context,
-        receiver: LocalIntentReceiver
+        receiver: LocalIntentReceiver,
+        activityStarter: ActivityStarter = ActivityStarter { intent ->
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
     ) {
         val intent = receiver.getResult()
         val status =
@@ -68,9 +90,8 @@ object PackageManagerUtil {
         val action =
             IntentCompat.getParcelableExtra(intent, Intent.EXTRA_INTENT, Intent::class.java)
 
-        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION && action != null) {
-            context.startActivity(action.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-            uninstallResultVerify(context, receiver)
+        if (handlePendingUserAction(status, action, activityStarter)) {
+            uninstallResultVerify(context, receiver, activityStarter)
             return
         }
 

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/DhizukuAppInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/DhizukuAppInstallerRepoImpl.kt
@@ -8,11 +8,16 @@ import com.rosan.dhizuku.api.Dhizuku
 import com.rosan.installer.core.reflection.ReflectionProvider
 import com.rosan.installer.framework.privileged.util.requireDhizukuPermissionGranted
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 
 class DhizukuAppInstallerRepoImpl(
-    context: Context, reflect: ReflectionProvider, capabilityProvider: DeviceCapabilityProvider, postInstallTaskProvider: PostInstallTaskProvider
-) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider) {
+    context: Context,
+    reflect: ReflectionProvider,
+    capabilityProvider: DeviceCapabilityProvider,
+    postInstallTaskProvider: PostInstallTaskProvider,
+    componentOpsProvider: ComponentOpsProvider
+) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider, componentOpsProvider) {
     override suspend fun iBinderWrapper(iBinder: IBinder): IBinder =
         requireDhizukuPermissionGranted {
             Dhizuku.binderWrapper(iBinder)

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/IBinderAppInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/IBinderAppInstallerRepoImpl.kt
@@ -4,6 +4,7 @@ package com.rosan.installer.data.engine.executor.appInstaller
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.IPackageInstaller
 import android.content.pm.IPackageInstallerSession
 import android.content.pm.IPackageManager
@@ -33,6 +34,7 @@ import com.rosan.installer.domain.engine.model.install.InstallOption
 import com.rosan.installer.domain.engine.model.install.sourcePath
 import com.rosan.installer.domain.engine.repository.AppInstallerRepository
 import com.rosan.installer.domain.privileged.model.PostInstallTaskInfo
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.domain.settings.model.config.ConfigModel
@@ -52,7 +54,8 @@ abstract class IBinderAppInstallerRepoImpl(
     protected val context: Context,
     protected val reflect: ReflectionProvider,
     protected val capabilityProvider: DeviceCapabilityProvider,
-    protected val postInstallTaskProvider: PostInstallTaskProvider
+    protected val postInstallTaskProvider: PostInstallTaskProvider,
+    protected val componentOpsProvider: ComponentOpsProvider
 ) : AppInstallerRepository {
     private val taskScope = CoroutineScope(Dispatchers.IO)
 
@@ -198,7 +201,11 @@ abstract class IBinderAppInstallerRepoImpl(
         )
 
         // The result verification logic remains the same.
-        PackageManagerUtil.uninstallResultVerify(context, receiver)
+        PackageManagerUtil.uninstallResultVerify(
+            context = context,
+            receiver = receiver,
+            activityStarter = pendingUserActionStarter(config)
+        )
     }
 
     private suspend fun doInnerWork(
@@ -240,7 +247,7 @@ abstract class IBinderAppInstallerRepoImpl(
         try {
             session = createSession(config, entities, packageInstaller, packageName)
             installIts(entities, session)
-            commit(session)
+            commit(session, config)
         } catch (e: Exception) {
             session?.abandon()
             throw e
@@ -380,11 +387,29 @@ abstract class IBinderAppInstallerRepoImpl(
     }
 
     @SuppressLint("RequestInstallPackagesPolicy")
-    private suspend fun commit(session: Session) {
+    private suspend fun commit(session: Session, config: ConfigModel) {
         val receiver = LocalIntentReceiver(reflect)
         session.commit(receiver.getIntentSender())
-        PackageManagerUtil.installResultVerify(context, receiver)
+        PackageManagerUtil.installResultVerify(
+            context = context,
+            receiver = receiver,
+            activityStarter = pendingUserActionStarter(config)
+        )
     }
+
+    private fun pendingUserActionStarter(config: ConfigModel): PackageManagerUtil.ActivityStarter =
+        PackageManagerUtil.ActivityStarter { intent ->
+            val startedPrivileged = runCatching {
+                componentOpsProvider.startActivityPrivileged(config, intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            }.getOrElse { error ->
+                Timber.w(error, "Privileged confirmation launch failed. Falling back to app context.")
+                false
+            }
+
+            if (!startedPrivileged) {
+                context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            }
+        }
 
     open suspend fun doFinishWork(
         config: ConfigModel,

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/ProcessAppInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/ProcessAppInstallerRepoImpl.kt
@@ -10,6 +10,7 @@ import com.rosan.installer.framework.privileged.util.SHELL_ROOT
 import com.rosan.installer.framework.privileged.util.SHELL_SH
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
 import com.rosan.installer.domain.engine.model.install.InstallEntity
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.domain.settings.model.config.ConfigModel
@@ -21,7 +22,8 @@ class ProcessAppInstallerRepoImpl(
     reflect: ReflectionProvider,
     capabilityProvider: DeviceCapabilityProvider,
     postInstallTaskProvider: PostInstallTaskProvider,
-) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider) {
+    componentOpsProvider: ComponentOpsProvider,
+) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider, componentOpsProvider) {
     private var localService: ProcessHookRecycler.HookedUserService? = null
 
     override suspend fun doInstallWork(

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/ShizukuAppInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/ShizukuAppInstallerRepoImpl.kt
@@ -8,11 +8,16 @@ import com.rosan.installer.core.reflection.ReflectionProvider
 import com.rosan.installer.framework.privileged.util.requireShizukuPermissionGranted
 
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 import rikka.shizuku.ShizukuBinderWrapper
 
 class ShizukuAppInstallerRepoImpl(
-    context: Context, reflect: ReflectionProvider, capabilityProvider: DeviceCapabilityProvider, postInstallTaskProvider: PostInstallTaskProvider
-) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider) {
+    context: Context,
+    reflect: ReflectionProvider,
+    capabilityProvider: DeviceCapabilityProvider,
+    postInstallTaskProvider: PostInstallTaskProvider,
+    componentOpsProvider: ComponentOpsProvider
+) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider, componentOpsProvider) {
     override suspend fun iBinderWrapper(iBinder: IBinder): IBinder = requireShizukuPermissionGranted { ShizukuBinderWrapper(iBinder) }
 }

--- a/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/SystemAppInstallerRepoImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/executor/appInstaller/SystemAppInstallerRepoImpl.kt
@@ -7,10 +7,15 @@ import android.os.IBinder
 import com.rosan.installer.core.reflection.ReflectionProvider
 
 import com.rosan.installer.domain.device.provider.DeviceCapabilityProvider
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 
 class SystemAppInstallerRepoImpl(
-    context: Context, reflect: ReflectionProvider, capabilityProvider: DeviceCapabilityProvider, postInstallTaskProvider: PostInstallTaskProvider
-) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider) {
+    context: Context,
+    reflect: ReflectionProvider,
+    capabilityProvider: DeviceCapabilityProvider,
+    postInstallTaskProvider: PostInstallTaskProvider,
+    componentOpsProvider: ComponentOpsProvider
+) : IBinderAppInstallerRepoImpl(context, reflect, capabilityProvider, postInstallTaskProvider, componentOpsProvider) {
     override suspend fun iBinderWrapper(iBinder: IBinder): IBinder = iBinder
 }

--- a/app/src/main/java/com/rosan/installer/data/engine/parser/ApkParser.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/parser/ApkParser.kt
@@ -322,7 +322,8 @@ class ApkParser(
                 sourceType = extra.dataType,
                 type = metadata.type,
                 filterType = metadata.filterType,
-                configValue = metadata.configValue
+                configValue = metadata.configValue,
+                installName = (data as? DataEntity.ZipFileEntity)?.name?.let(::File)?.name ?: "$splitName.apk"
             )
         }
     }

--- a/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/ApkmStrategy.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/ApkmStrategy.kt
@@ -71,7 +71,8 @@ class ApkmStrategy(
                                 sourceType = extra.dataType,
                                 type = metadata.type,
                                 filterType = metadata.filterType,
-                                configValue = metadata.configValue
+                                configValue = metadata.configValue,
+                                installName = file.name
                             )
                         } else {
                             AppEntity.BaseEntity(

--- a/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/ApksStrategy.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/ApksStrategy.kt
@@ -105,7 +105,8 @@ class ApksStrategy(
                 sourceType = extra.dataType,
                 type = metadata.type,
                 filterType = metadata.filterType,
-                configValue = metadata.configValue
+                configValue = metadata.configValue,
+                installName = File(entry.name).name
             )
         }
 

--- a/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/XApkStrategy.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/parser/strategy/XApkStrategy.kt
@@ -73,7 +73,8 @@ class XApkStrategy(
                             sourceType = extra.dataType,
                             type = metadata.type,
                             filterType = metadata.filterType,
-                            configValue = metadata.configValue
+                            configValue = metadata.configValue,
+                            installName = file.name
                         )
                     } else {
                         // Handle Base APK

--- a/app/src/main/java/com/rosan/installer/data/engine/repository/AppInstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/rosan/installer/data/engine/repository/AppInstallerRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.rosan.installer.domain.engine.model.install.InstallEntity
 import com.rosan.installer.domain.engine.repository.AppInstallerRepository
 import com.rosan.installer.domain.privileged.exception.PrivilegedException
 import com.rosan.installer.domain.privileged.model.PrivilegedErrorType
+import com.rosan.installer.domain.privileged.provider.ComponentOpsProvider
 import com.rosan.installer.domain.privileged.provider.PostInstallTaskProvider
 import com.rosan.installer.domain.settings.model.config.Authorizer
 import com.rosan.installer.domain.settings.model.config.ConfigModel
@@ -22,7 +23,8 @@ class AppInstallerRepositoryImpl(
     private val context: Context,
     private val reflect: ReflectionProvider,
     private val deviceCapabilityProvider: DeviceCapabilityProvider,
-    private val postInstallTaskProvider: PostInstallTaskProvider
+    private val postInstallTaskProvider: PostInstallTaskProvider,
+    private val componentOpsProvider: ComponentOpsProvider
 ) : AppInstallerRepository {
     override suspend fun doInstallWork(
         config: ConfigModel,
@@ -92,17 +94,17 @@ class AppInstallerRepositoryImpl(
      */
     private fun resolveRepo(config: ConfigModel): AppInstallerRepository {
         return when (config.authorizer) {
-            Authorizer.Shizuku -> ShizukuAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider)
-            Authorizer.Dhizuku -> DhizukuAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider)
+            Authorizer.Shizuku -> ShizukuAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider, componentOpsProvider)
+            Authorizer.Dhizuku -> DhizukuAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider, componentOpsProvider)
             Authorizer.None -> {
                 if (deviceCapabilityProvider.isSystemApp) {
-                    SystemAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider)
+                    SystemAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider, componentOpsProvider)
                 } else {
                     NoneAppInstallerRepoImpl(context, reflect, postInstallTaskProvider)
                 }
             }
 
-            else -> ProcessAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider)
+            else -> ProcessAppInstallerRepoImpl(context, reflect, deviceCapabilityProvider, postInstallTaskProvider, componentOpsProvider)
         }
     }
 }

--- a/app/src/main/java/com/rosan/installer/data/session/handler/ActionHandler.kt
+++ b/app/src/main/java/com/rosan/installer/data/session/handler/ActionHandler.kt
@@ -97,7 +97,8 @@ class ActionHandler(
         context = context,
         networkResolver = networkResolver,
         cacheDirectory = cacheDirectory,
-        progressFlow = mutableProgressFlow
+        progressFlow = mutableProgressFlow,
+        shellExecutionProvider = shellExecutionProvider
     )
 
     override suspend fun onStart() {
@@ -235,7 +236,7 @@ class ActionHandler(
 
         // Resolve Data (IO Heavy - Cancellable via SourceResolver)
         Timber.d("[id=$sessionId] resolve: Resolving data URIs...")
-        val resolveResult = sourceResolver.resolve(activity.intent)
+        val resolveResult = sourceResolver.resolve(activity.intent, session.config)
 
         // Check active after IO
         if (!currentCoroutineContext().isActive) throw CancellationException()

--- a/app/src/main/java/com/rosan/installer/data/session/resolver/SourceResolver.kt
+++ b/app/src/main/java/com/rosan/installer/data/session/resolver/SourceResolver.kt
@@ -18,7 +18,10 @@ import com.rosan.installer.data.session.util.getRealPathFromUri
 import com.rosan.installer.data.session.util.pathUnify
 import com.rosan.installer.data.session.util.transferWithProgress
 import com.rosan.installer.domain.engine.model.source.DataEntity
+import com.rosan.installer.domain.privileged.provider.ShellExecutionProvider
 import com.rosan.installer.domain.session.exception.ResolveException
+import com.rosan.installer.domain.settings.model.config.Authorizer
+import com.rosan.installer.domain.settings.model.config.ConfigModel
 import com.rosan.installer.domain.session.model.ProgressEntity
 import com.rosan.installer.domain.session.model.ResolveErrorType
 import com.rosan.installer.domain.session.model.ResolveResult
@@ -40,13 +43,14 @@ class SourceResolver(
     private val context: Context,
     private val networkResolver: NetworkResolver,
     private val cacheDirectory: String,
-    private val progressFlow: MutableSharedFlow<ProgressEntity>
+    private val progressFlow: MutableSharedFlow<ProgressEntity>,
+    private val shellExecutionProvider: ShellExecutionProvider
 ) {
     private val closeables = mutableListOf<Closeable>()
 
     fun getTrackedCloseables(): List<Closeable> = closeables
 
-    suspend fun resolve(intent: Intent): ResolveResult {
+    suspend fun resolve(intent: Intent, config: ConfigModel): ResolveResult {
         val uris = extractUris(intent)
         Timber.d("resolve: URIs extracted from intent (${uris.size}).")
 
@@ -54,7 +58,7 @@ class SourceResolver(
         for (uri in uris) {
             // Check cancellation between items
             if (!currentCoroutineContext().isActive) throw CancellationException()
-            data.addAll(resolveSingleUri(uri))
+            data.addAll(resolveSingleUri(uri, config))
         }
 
         // Return the packaged result
@@ -158,7 +162,7 @@ class SourceResolver(
         return uris
     }
 
-    private suspend fun resolveSingleUri(uri: Uri): List<DataEntity> {
+    private suspend fun resolveSingleUri(uri: Uri, config: ConfigModel): List<DataEntity> {
         Timber.d("Source URI: $uri")
 
         // Handle null scheme (unlikely but safe to handle)
@@ -171,7 +175,7 @@ class SourceResolver(
                 listOf(DataEntity.FileEntity(path).apply { source = DataEntity.FileEntity(path) })
             }
 
-            "content" -> resolveContentUri(uri)
+            "content" -> resolveContentUri(uri, config)
 
             "http", "https" -> {
                 if (!AppConfig.isInternetAccessEnabled) {
@@ -192,7 +196,7 @@ class SourceResolver(
         }
     }
 
-    private suspend fun resolveContentUri(uri: Uri): List<DataEntity> {
+    private suspend fun resolveContentUri(uri: Uri, config: ConfigModel): List<DataEntity> {
         val afd = try {
             context.contentResolver?.openAssetFileDescriptor(uri, "r")
                 ?: throw IOException("Cannot open file descriptor: $uri")
@@ -208,7 +212,12 @@ class SourceResolver(
                 )
             }
 
-            // Rethrow if it doesn't match the signature or initiator is unknown
+            if (shouldAttemptPrivilegedCopy(e, config)) {
+                Timber.w(e, "SecurityException caught for private content URI. Trying privileged copy fallback.")
+                tryPrivilegedCopyContentUriToCache(uri, config)?.let { return it }
+            }
+
+            // Rethrow if privileged fallback failed or is unavailable.
             throw e
         }
         // Resolve real path
@@ -243,6 +252,47 @@ class SourceResolver(
 
         return cacheStream(uri, afd, realPath)
     }
+
+    private suspend fun tryPrivilegedCopyContentUriToCache(uri: Uri, config: ConfigModel): List<DataEntity>? =
+        withContext(Dispatchers.IO) {
+            val tempFile = File.createTempFile(UUID.randomUUID().toString(), ".cache", File(cacheDirectory))
+            val escapedUri = uri.toString().shellQuote()
+            val escapedTempPath = tempFile.absolutePath.shellQuote()
+            val command = "content read --uri $escapedUri > $escapedTempPath && [ -s $escapedTempPath ]"
+            val result = runCatching {
+                shellExecutionProvider.executeCommandArray(config, arrayOf("sh", "-c", command))
+            }.getOrElse { error ->
+                Timber.w(error, "Privileged copy command failed for $uri")
+                tempFile.delete()
+                return@withContext null
+            }
+
+            if (result.startsWith("Exit Code", ignoreCase = true) || !tempFile.exists() || tempFile.length() <= 0L) {
+                Timber.w("Privileged copy fallback failed for $uri: $result")
+                tempFile.delete()
+                return@withContext null
+            }
+
+            listOf(DataEntity.FileEntity(tempFile.absolutePath).apply { source = DataEntity.FileEntity(tempFile.absolutePath) })
+        }
+
+    internal fun shouldAttemptPrivilegedCopy(e: SecurityException, config: ConfigModel): Boolean {
+        val supportsPrivilegedCopy = when (config.authorizer) {
+            Authorizer.Root,
+            Authorizer.Customize,
+            Authorizer.Shizuku,
+            Authorizer.Dhizuku -> true
+            else -> false
+        }
+        if (!supportsPrivilegedCopy) {
+            return false
+        }
+
+        val message = e.message?.lowercase() ?: return false
+        return "permission denial" in message && "not exported" in message && "fileprovider" in message
+    }
+
+    private fun String.shellQuote(): String = "'" + replace("'", "'\\''") + "'"
 
     private suspend fun cacheStream(uri: Uri, afd: AssetFileDescriptor, sourcePath: String): List<DataEntity> =
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/rosan/installer/data/session/resolver/SourceResolver.kt
+++ b/app/src/main/java/com/rosan/installer/data/session/resolver/SourceResolver.kt
@@ -86,7 +86,8 @@ class SourceResolver(
                     }
                 }
 
-                // 2. Fallback to Stream/ClipData if no URL found (Handles file sharing, including text files like logcat.txt)
+                // 2. Merge Stream + ClipData when no URL was found.
+                // Some installers put the primary APK in EXTRA_STREAM and the remaining split APKs in ClipData.
                 if (uris.isEmpty()) {
                     val streamUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                         intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
@@ -97,16 +98,13 @@ class SourceResolver(
 
                     if (streamUri != null) uris.add(streamUri)
 
-                    // 3. Check ClipData (Common in modern Android sharing)
-                    if (uris.isEmpty()) {
-                        intent.clipData?.let { clip ->
-                            for (i in 0 until clip.itemCount) {
-                                clip.getItemAt(i).uri?.let { uris.add(it) }
-                            }
+                    intent.clipData?.let { clip ->
+                        for (i in 0 until clip.itemCount) {
+                            clip.getItemAt(i).uri?.takeIf { it !in uris }?.let { uris.add(it) }
                         }
                     }
 
-                    // 4. Fallback to EXTRA_TEXT only if no file stream was found and type indicates text
+                    // 3. Fallback to EXTRA_TEXT only if no file stream was found and type indicates text
                     if (uris.isEmpty() && intent.type?.startsWith("text/") == true) {
                         val text = intent.getStringExtra(Intent.EXTRA_TEXT)?.trim()
                         if (!text.isNullOrBlank()) {
@@ -279,9 +277,7 @@ class SourceResolver(
     internal fun shouldAttemptPrivilegedCopy(e: SecurityException, config: ConfigModel): Boolean {
         val supportsPrivilegedCopy = when (config.authorizer) {
             Authorizer.Root,
-            Authorizer.Customize,
-            Authorizer.Shizuku,
-            Authorizer.Dhizuku -> true
+            Authorizer.Customize -> true
             else -> false
         }
         if (!supportsPrivilegedCopy) {
@@ -294,10 +290,41 @@ class SourceResolver(
 
     private fun String.shellQuote(): String = "'" + replace("'", "'\\''") + "'"
 
+    private fun createCacheFile(displayName: String?): File {
+        return createTempFile(displayName, File(cacheDirectory))
+    }
+
+    private fun createPrivilegedCopyTargetFile(displayName: String?): File {
+        val externalDir = context.externalCacheDir?.let { File(it, "installer_sessions") }
+        val targetDir = externalDir ?: File(cacheDirectory)
+        targetDir.mkdirs()
+        return createTempFile(displayName, targetDir)
+    }
+
+    private fun createTempFile(displayName: String?, directory: File): File {
+        val sanitizedName = displayName
+            ?.substringAfterLast('/')
+            ?.takeIf { it.isNotBlank() }
+            ?.replace(Regex("[^A-Za-z0-9._-]"), "_")
+            ?: "${UUID.randomUUID()}.cache"
+        val uniqueName = "${UUID.randomUUID()}_$sanitizedName"
+        return File(directory, uniqueName)
+    }
+
+    private fun resolveDisplayName(uri: Uri): String? = runCatching {
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use null
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (nameIndex == -1 || cursor.isNull(nameIndex)) null else cursor.getString(nameIndex)
+            }
+    }.getOrNull()
+
     private suspend fun cacheStream(uri: Uri, afd: AssetFileDescriptor, sourcePath: String): List<DataEntity> =
         withContext(Dispatchers.IO) {
             afd.use { descriptor ->
-                val tempFile = File.createTempFile(UUID.randomUUID().toString(), ".cache", File(cacheDirectory))
+                val displayName = resolveDisplayName(uri)
+                val tempFile = createCacheFile(displayName)
                 val knownLength =
                     if (descriptor.declaredLength != AssetFileDescriptor.UNKNOWN_LENGTH) descriptor.declaredLength else guessContentLength(
                         uri,
@@ -336,7 +363,13 @@ class SourceResolver(
                     }
                 }
 
-                listOf(DataEntity.FileEntity(tempFile.absolutePath).apply { source = DataEntity.FileEntity(sourcePath) })
+                listOf(DataEntity.FileEntity(tempFile.absolutePath).apply {
+                    source = DataEntity.FileEntity(
+                        displayName
+                            ?: sourcePath.takeIf { it.isNotBlank() }
+                            ?: tempFile.absolutePath
+                    )
+                })
             }
         }
 

--- a/app/src/main/java/com/rosan/installer/domain/engine/model/packageinfo/AppEntity.kt
+++ b/app/src/main/java/com/rosan/installer/domain/engine/model/packageinfo/AppEntity.kt
@@ -61,7 +61,9 @@ sealed class AppEntity {
         // and can be installed as long as the user wants it.
         val filterType: FilterType = FilterType.NONE,
         // Extracted config value ("zh", "xhdpi", "arm64-v8a")
-        val configValue: String? = null
+        val configValue: String? = null,
+        // Original archive entry name used when writing into PackageInstaller.Session.
+        val installName: String = "$splitName.apk"
     ) : AppEntity() {
         override val name = "$splitName.apk"
     }

--- a/app/src/main/java/com/rosan/installer/domain/engine/usecase/ProcessInstallationUseCase.kt
+++ b/app/src/main/java/com/rosan/installer/domain/engine/usecase/ProcessInstallationUseCase.kt
@@ -197,7 +197,7 @@ class ProcessInstallationUseCase(
 
         val installEntities = selectedEntities.map {
             InstallEntity(
-                name = it.app.name,
+                name = (it.app as? AppEntity.SplitEntity)?.installName ?: it.app.name,
                 packageName = it.app.packageName,
                 sharedUserId = (it.app as? AppEntity.BaseEntity)?.sharedUserId,
                 arch = it.app.arch,

--- a/app/src/test/java/com/rosan/installer/data/engine/executor/PackageManagerUtilTest.kt
+++ b/app/src/test/java/com/rosan/installer/data/engine/executor/PackageManagerUtilTest.kt
@@ -1,0 +1,61 @@
+package com.rosan.installer.data.engine.executor
+
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PackageManagerUtilTest {
+    @Test
+    fun `handlePendingUserAction starts launcher for pending status`() = runTest {
+        val launched = mutableListOf<Intent>()
+        val action = Intent("test.action.INSTALL_CONFIRM")
+
+        val handled = PackageManagerUtil.handlePendingUserAction(
+            status = PackageInstaller.STATUS_PENDING_USER_ACTION,
+            action = action,
+            activityStarter = PackageManagerUtil.ActivityStarter { intent ->
+                launched += intent
+            }
+        )
+
+        assertTrue(handled)
+        assertEquals(listOf(action), launched)
+    }
+
+    @Test
+    fun `handlePendingUserAction ignores non pending status`() = runTest {
+        val launched = mutableListOf<Intent>()
+        val action = Intent("test.action.INSTALL_CONFIRM")
+
+        val handled = PackageManagerUtil.handlePendingUserAction(
+            status = PackageInstaller.STATUS_SUCCESS,
+            action = action,
+            activityStarter = PackageManagerUtil.ActivityStarter { intent ->
+                launched += intent
+            }
+        )
+
+        assertFalse(handled)
+        assertTrue(launched.isEmpty())
+    }
+
+    @Test
+    fun `handlePendingUserAction ignores missing action intent`() = runTest {
+        val launched = mutableListOf<Intent>()
+
+        val handled = PackageManagerUtil.handlePendingUserAction(
+            status = PackageInstaller.STATUS_PENDING_USER_ACTION,
+            action = null,
+            activityStarter = PackageManagerUtil.ActivityStarter { intent ->
+                launched += intent
+            }
+        )
+
+        assertFalse(handled)
+        assertTrue(launched.isEmpty())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ uiautomator = "2.3.0"
 benchmarkMacroJunit4 = "1.4.1"
 baselineprofile = "1.5.0-alpha06"
 profileinstaller = "1.4.1"
+coroutinesTest = "1.10.2"
 
 [plugins]
 installerx-application = { id = "installerx.android.application" }
@@ -146,3 +147,4 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }


### PR DESCRIPTION
## Summary

This PR fixes installation from private APK content URIs when the selected installer backend has elevated access but the normal app process cannot read the source APK.

The main scenario is using InstallerX Revived through an external default-installer locker instead of the built-in default-installer flow. In that setup, the incoming APK may be stored in a system-managed temporary location that is not readable by the normal app process. Previously, resolving that APK failed with a permission error.

This change adds a fallback path:

- when opening a private `content://` APK fails with a matching permission denial, and the selected authorizer supports elevated execution, copy the APK into InstallerX Revived's cache through that authorizer;
- keep the existing normal resolver behavior for readable files and non-elevated modes;
- reuse the elevated activity launcher for pending install confirmation in elevated installer implementations;
- add unit coverage for the extracted pending-user-action handling.

## Verification

Tested on my device with two elevated access providers. APKs from the affected external default-installer flow now install successfully after this change. Before this change, the same flow failed because the normal app process could not read the source APK.